### PR TITLE
Add an srp for a cardano-ledger with the UTxO decoding fix

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,6 +19,16 @@ index-state:
 packages:
   cardano-cli
 
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-ledger.git
+  --sha256: sha256-L+EZEiv/YBjDPMJjYxbFBu97CFy4S4MefJh7SjbwvWc=
+  -- release/cardano-ledger-core-1.18.0.0-hotfix
+  tag: a644b83b5c2ccb2721242ffe0e9fd5687fdb11be
+  subdir:
+    eras/babbage/impl
+    libs/cardano-ledger-core
+
 program-options
   ghc-options: -Werror
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Hotfix for `cardano-cli-10.15.0.0` to fix a decoding error when querying the whole UTxO
  type:
  - bugfix         # fixes a defect
```

# Context

The bug was reported by @CarlosLopezDeLara on 2026-03-03. It affects only queries, and only when querying the whole UTxO because of some historical TxOuts that are no longer relevant.

# How to trust this PR

The only change is an srp (source-repository-package) stanza pointing to a branch in `cardano-ledger` that contains a couple of small fixes to decoding.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff