### PR TITLE
Use cardano-api with ouroboros-consensus ^>=3.0 for node 10.7.2 

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -87,3 +87,9 @@ if impl (ghc >= 9.14)
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api.git
+  tag: 6795cad948bd6dfbd44e59ce8e6d51feaf0df3d8
+  --sha256: sha256-zkGU4kh3bBYqN39aL3CXVzh4w6G6ZnlxoK7I1TBDbV8=
+  subdir: cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-02-17T10:15:41Z
-  , cardano-haskell-packages 2026-04-02T17:15:57Z
+  , cardano-haskell-packages 2026-04-07T20:21:55Z
 
 active-repositories:
   , :rest

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1775175350,
-        "narHash": "sha256-Iff28reEPMMfvTQyrlxPzz9p6UudvKSG7Jm2p4RdaXc=",
+        "lastModified": 1775608993,
+        "narHash": "sha256-AHi1GtyIWNox83Hzwdt9lyaTCI2OK7DuztJtBVIzRsQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "83cd31bd506df35547bdd7855aec651178eebceb",
+        "rev": "32b5f2ab66b36dd3acf57641ef14a192d1bb6f3b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    <insert-changelog-description-here>
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Points cardano-cli at the cardano-api branch (`geo2a/bump-consensus`) which bumps the `ouroboros-consensus` dependency bound from `^>=2.0` to `^>=3.0`, required for `cardano-node 10.7.2`.

Uses a temporary `source-repository-package` stanza. This can be removed once the CHaP metadata revision for `cardano-api-10.26.0.0` lands.

Related: https://github.com/IntersectMBO/cardano-api/pull/1178


# How to trust this PR


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
