### PR TITLE
Drop redundant ProtocolParametersUpdate conversion in shelleyToBabbage update

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Run.hs
@@ -139,9 +139,6 @@ shelleyToBabbageProtocolParametersUpdate sbe args = do
 
   eraBasedPParams <- maybeAddUpdatedCostModel args
 
-  let updateProtocolParams = createEraBasedProtocolParamUpdate sbe eraBasedPParams
-      apiUpdateProtocolParamsType = fromLedgerPParamsUpdate sbe updateProtocolParams
-
   genVKeys <-
     sequence
       [ fromEitherIOCli $
@@ -150,7 +147,7 @@ shelleyToBabbageProtocolParametersUpdate sbe args = do
       ]
 
   let genKeyHashes = fmap verificationKeyHash genVKeys
-      upProp = makeShelleyUpdateProposal apiUpdateProtocolParamsType genKeyHashes expEpoch
+      upProp = makeShelleyUpdateProposal eraBasedPParams genKeyHashes expEpoch
 
   fromEitherIOCli @(FileError ()) $
     shelleyBasedEraConstraints sbe $


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Drop the redundant `createEraBasedProtocolParamUpdate` /
    `fromLedgerPParamsUpdate` round-trip in
    `shelleyToBabbageProtocolParametersUpdate`; pass
    `EraBasedProtocolParametersUpdate era` straight to
    `makeShelleyUpdateProposal`.
# uncomment types applicable to the change:
  type:
   - refactoring    # QoL changes
# uncomment at least one main project this PR is associated with
  projects:
   - cardano-cli
```

# Context

`makeShelleyUpdateProposal` (`cardano-api ^>=11.1`, already required on master) accepts `EraBasedProtocolParametersUpdate era` directly. The existing code in `shelleyToBabbageProtocolParametersUpdate` constructed that value, converted it to the deprecated `ProtocolParametersUpdate` via `createEraBasedProtocolParamUpdate` / `fromLedgerPParamsUpdate`, then passed the result to `makeShelleyUpdateProposal` — an unnecessary round-trip through the old API.

No behaviour change: the function still produces the same `UpdateProposal era` text envelope.

# How to trust this PR

- `cabal build cardano-cli -j4` builds cleanly.
- `Test.Cli.Compatible.Transaction.Build` exercises `compatible <era> governance action create-protocol-parameters-update` for shelley/allegra/mary/alonzo/babbage and diffs each against a reference produced via the same code path — passing means the produced text envelope is byte-identical to before.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff