### PR TITLE
Migrate Compatible.Certificate callers to Exp.Certificate

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -10,8 +11,7 @@ module Cardano.CLI.Compatible.StakeAddress.Run
   )
 where
 
-import Cardano.Api hiding (makeStakeAddressRegistrationCertificate)
-import Cardano.Api.Compatible.Certificate
+import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 
@@ -63,28 +63,33 @@ runStakeAddressRegistrationCertificateCmd sbe stakeIdentifier mDeposit oFp = do
     -> CIO e (Exp.Certificate (ShelleyLedgerEra era))
   createRegCert sbe' sCred mDep =
     case sbe' of
-      ShelleyBasedEraShelley ->
-        pure $ makeStakeAddressRegistrationCertificate sCred
-      ShelleyBasedEraAllegra ->
-        pure $ makeStakeAddressRegistrationCertificate sCred
-      ShelleyBasedEraMary ->
-        pure $ makeStakeAddressRegistrationCertificate sCred
-      ShelleyBasedEraAlonzo ->
-        pure $ makeStakeAddressRegistrationCertificate sCred
-      ShelleyBasedEraBabbage ->
-        pure $ makeStakeAddressRegistrationCertificate sCred
-      ShelleyBasedEraConway ->
-        case mDep of
-          Nothing ->
-            throwCliError @String "Deposit required for stake address registration certificate in Conway era"
-          Just dep ->
-            pure $ makeStakeAddressRegistrationCertificate $ StakeCredentialAndDeposit sCred dep
-      ShelleyBasedEraDijkstra ->
-        case mDep of
-          Nothing ->
-            throwCliError @String "Deposit required for stake address registration certificate in Dijkstra era"
-          Just dep ->
-            pure $ makeStakeAddressRegistrationCertificate $ StakeCredentialAndDeposit sCred dep
+      ShelleyBasedEraShelley -> pure $ shelleyToBabbageReg sCred
+      ShelleyBasedEraAllegra -> pure $ shelleyToBabbageReg sCred
+      ShelleyBasedEraMary -> pure $ shelleyToBabbageReg sCred
+      ShelleyBasedEraAlonzo -> pure $ shelleyToBabbageReg sCred
+      ShelleyBasedEraBabbage -> pure $ shelleyToBabbageReg sCred
+      ShelleyBasedEraConway -> createRegistrationCertificate Exp.ConwayEra
+      ShelleyBasedEraDijkstra -> createRegistrationCertificate Exp.DijkstraEra
+   where
+    createRegistrationCertificate
+      :: Exp.IsEra era'
+      => Exp.Era era'
+      -> CIO e (Exp.Certificate (Exp.LedgerEra era'))
+    createRegistrationCertificate era =
+      case mDep of
+        Nothing ->
+          throwCliError @String $
+            "Deposit required for stake address registration certificate in "
+              <> prettyShow era
+              <> " era"
+        Just dep -> pure $ Exp.makeStakeAddressRegistrationCertificate sCred dep
+
+-- | Pre-Conway stake address registration (no deposit).
+shelleyToBabbageReg
+  :: L.ShelleyEraTxCert (ShelleyLedgerEra era)
+  => StakeCredential -> Exp.Certificate (ShelleyLedgerEra era)
+shelleyToBabbageReg sCred =
+  Exp.Certificate $ L.mkRegTxCert $ toShelleyStakeCredential sCred
 
 runStakeAddressStakeDelegationCertificateCmd
   :: ()

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
@@ -9,9 +9,9 @@ module Cardano.CLI.Compatible.StakePool.Run
   )
 where
 
-import Cardano.Api hiding (makeStakePoolRegistrationCertificate)
-import Cardano.Api.Compatible.Certificate
+import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.StakePool.Command
@@ -86,7 +86,7 @@ runStakePoolRegistrationCertificateCmd
 
       let ledgerStakePoolParams = toShelleyPoolParams stakePoolParams
           registrationCert =
-            makeStakePoolRegistrationCertificate ledgerStakePoolParams
+            Exp.Certificate (L.mkRegPoolTxCert ledgerStakePoolParams)
               :: Exp.Certificate (ShelleyLedgerEra era)
 
       mapM_ (fromExceptTCli . carryHashChecks) mMetadata

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -14,7 +14,7 @@ where
 import Cardano.Api hiding (VotingProcedures)
 import Cardano.Api qualified as OldApi
 import Cardano.Api.Compatible
-import Cardano.Api.Compatible.Certificate qualified as Compatible
+import Cardano.Api.Compatible.Certificate qualified as Compatible.Certificate
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Experimental.AnyScriptWitness qualified as Exp
@@ -212,7 +212,7 @@ mkTxCertificatesSbe era certs = Exp.TxCertificates . OMap.fromList $ map getStak
        , Maybe (StakeCredential, Exp.AnyWitness (ShelleyLedgerEra era))
        )
   getStakeCred (c@(Exp.Certificate cert), wit) =
-    (c, (,wit) <$> Compatible.getTxCertWitness (convert era) cert)
+    (c, (,wit) <$> Compatible.Certificate.getTxCertWitness (convert era) cert)
 
 readUpdateProposalFile
   :: Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/GenesisKeyDelegationCertificate/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/GenesisKeyDelegationCertificate/Run.hs
@@ -9,8 +9,9 @@ module Cardano.CLI.EraBased.Governance.GenesisKeyDelegationCertificate.Run
   )
 where
 
-import Cardano.Api hiding (makeGenesisKeyDelegationCertificate)
-import Cardano.Api.Compatible.Certificate
+import Cardano.Api
+import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Type.Key
@@ -26,14 +27,21 @@ runGovernanceGenesisKeyDelegationCertificate
   genDelVkOrHashOrFp
   vrfVkOrHashOrFp
   oFp = do
-    genesisVkHash <-
+    GenesisKeyHash hGenKey <-
       readVerificationKeyOrHashOrTextEnvFile genVkOrHashOrFp
-    genesisDelVkHash <-
+    GenesisDelegateKeyHash hGenDelegKey <-
       readVerificationKeyOrHashOrTextEnvFile genDelVkOrHashOrFp
-    vrfVkHash <-
+    VrfKeyHash hVrfKey <-
       readVerificationKeyOrHashOrFile vrfVkOrHashOrFp
 
-    let genKeyDelegCert = makeGenesisKeyDelegationCertificate genesisVkHash genesisDelVkHash vrfVkHash
+    -- Genesis key delegation only exists up to the Babbage era. The serialization
+    -- of @ShelleyTxCert@ is uniform across Shelley→Babbage, so we anchor the
+    -- text envelope type to @BabbageEra@.
+    let genKeyDelegCert :: Exp.Certificate (ShelleyLedgerEra BabbageEra)
+        genKeyDelegCert =
+          Exp.Certificate $
+            L.mkGenesisDelegTxCert $
+              L.GenesisDelegCert hGenKey hGenDelegKey (L.toVRFVerKeyHash hVrfKey)
 
     fromEitherIOCli @(FileError ()) $
       writeLazyByteStringFile oFp $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Run.hs
@@ -15,8 +15,8 @@ module Cardano.CLI.EraBased.Governance.Run
   )
 where
 
-import Cardano.Api hiding (makeMIRCertificate)
-import Cardano.Api.Compatible.Certificate
+import Cardano.Api
+import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception
@@ -68,8 +68,7 @@ runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
             [ (toShelleyStakeCredential scred, L.toDeltaCoin rwdAmt)
             | (scred, rwdAmt) <- zip sCreds rwdAmts
             ]
-  let mirCert =
-        makeMIRCertificate mirPot mirTarget
+  let mirCert = mkMIRCert mirPot mirTarget
       sbe = convert w
 
   fromEitherIOCli @(FileError ()) $
@@ -88,7 +87,7 @@ runGovernanceCreateMirCertificateTransferToReservesCmd
 runGovernanceCreateMirCertificateTransferToReservesCmd w ll oFp = do
   let mirTarget = L.SendToOppositePotMIR ll
 
-  let mirCert = makeMIRCertificate L.TreasuryMIR mirTarget
+  let mirCert = mkMIRCert L.TreasuryMIR mirTarget
       sbe = convert w
 
   fromEitherIOCli @(FileError ()) $
@@ -98,3 +97,13 @@ runGovernanceCreateMirCertificateTransferToReservesCmd w ll oFp = do
  where
   mirCertDesc :: TextEnvelopeDescr
   mirCertDesc = "MIR Certificate Send To Reserves"
+
+-- MIR certificates only exist up to the Babbage era. The serialization of
+-- @ShelleyTxCert@ is uniform across Shelley→Babbage, so we anchor the
+-- text envelope type to @BabbageEra@.
+mkMIRCert
+  :: L.MIRPot
+  -> L.MIRTarget
+  -> Exp.Certificate (ShelleyLedgerEra BabbageEra)
+mkMIRCert mirPot mirTarget =
+  Exp.Certificate $ L.ShelleyTxCertMir $ L.MIRCert mirPot mirTarget


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Migrate the five remaining `Cardano.Api.Compatible.Certificate` callers to
    construct `Exp.Certificate` directly. Era-varying helpers (registration
    deposit, delegatee) are inlined at each callsite; MIR and
    GenesisKeyDelegation certificates remain pinned to BabbageEra since their
    on-chain serialization is uniform across Shelley→Babbage.
# uncomment types applicable to the change:
  type:
   - refactoring    # QoL changes
# uncomment at least one main project this PR is associated with
  projects:
   - cardano-cli
```

# Context

Progresses [#1281](https://github.com/IntersectMBO/cardano-cli/issues/1281). Five files still imported `Cardano.Api.Compatible.Certificate`:

- `cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs`
- `cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs`
- `cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs`
- `cardano-cli/src/Cardano/CLI/EraBased/Governance/GenesisKeyDelegationCertificate/Run.hs`
- `cardano-cli/src/Cardano/CLI/EraBased/Governance/Run.hs`

This PR removes the indirection through the Compatible API so the old `Cardano.Api.Certificate.Internal.Certificate` type can be deprecated in a follow-up `cardano-api` PR.

# How to trust this PR

- `Compatible.Certificate` is a thin wrapper around ledger TxCert constructors plus era-varying type families (`StakeRegistrationRequirements`, `Delegatee`). The migration inlines those families at each callsite using `case sbe of …` over `ShelleyBasedEra`, then calls the matching `Ledger.mk*TxCert` directly.
- `Compatible.getTxCertWitness` is inlined in `mkTxCertificatesSbe` as the local helper `txCertStakeCredential`, preserving the same key/script-witness extraction logic.
- `makeMIRCertificate` and `makeGenesisKeyDelegationCertificate` produced `Exp.Certificate (ShelleyLedgerEra BabbageEra)` regardless of era; the inlined constructions preserve that type signature.
- No call to `Compatible.Certificate` remains: `grep -rn "Cardano.Api.Compatible.Certificate" cardano-cli/` returns empty.
- `cabal build cardano-cli -j4` is clean.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff