### PR TITLE
Add --key-output-bech32/--key-output-text-envelope to governance key-gen commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
@@ -316,8 +316,8 @@ runGenesisCreateTestNetDataCmd
           skeyHotFile = File @(SigningKey ()) $ committeeDir </> "cc.hot.skey"
           vkeyColdFile = File @(VerificationKey ()) $ committeeDir </> "cc.cold.vkey"
           skeyColdFile = File @(SigningKey ()) $ committeeDir </> "cc.cold.skey"
-          hotArgs = CC.GovernanceCommitteeKeyGenHotCmdArgs eon vkeyHotFile skeyHotFile
-          coldArgs = CC.GovernanceCommitteeKeyGenColdCmdArgs eon vkeyColdFile skeyColdFile
+          hotArgs = CC.GovernanceCommitteeKeyGenHotCmdArgs eon desiredKeyOutputFormat vkeyHotFile skeyHotFile
+          coldArgs = CC.GovernanceCommitteeKeyGenColdCmdArgs eon desiredKeyOutputFormat vkeyColdFile skeyColdFile
       liftIO $ createDirectoryIfMissing True committeeDir
       void $
         CC.runGovernanceCommitteeKeyGenHot hotArgs
@@ -337,7 +337,7 @@ runGenesisCreateTestNetDataCmd
           let drepDir = drepsDir </> "drep" <> show index
               vkeyFile = File @(VerificationKey ()) $ drepDir </> "drep.vkey"
               skeyFile = File @(SigningKey ()) $ drepDir </> "drep.skey"
-              cmd = DRep.GovernanceDRepKeyGenCmdArgs eon vkeyFile skeyFile
+              cmd = DRep.GovernanceDRepKeyGenCmdArgs eon desiredKeyOutputFormat vkeyFile skeyFile
           liftIO $ createDirectoryIfMissing True drepDir
           fst <$> DRep.runGovernanceDRepKeyGenCmd cmd
         Transient ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Command.hs
@@ -17,9 +17,16 @@ import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L
 
-import Cardano.CLI.Type.Common (PotentiallyCheckedAnchor, ResignationMetadataUrl)
+import Cardano.CLI.Type.Common
+  ( FormatBech32
+  , FormatTextEnvelope
+  , PotentiallyCheckedAnchor
+  , ResignationMetadataUrl
+  )
 import Cardano.CLI.Type.Key
 import Cardano.CLI.Type.Key.VerificationKey
+
+import Vary
 
 data GovernanceCommitteeCmds era
   = GovernanceCommitteeKeyGenColdCmd
@@ -37,6 +44,7 @@ data GovernanceCommitteeCmds era
 data GovernanceCommitteeKeyGenColdCmdArgs era
   = GovernanceCommitteeKeyGenColdCmdArgs
   { era :: !(Exp.Era era)
+  , keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , vkeyOutFile :: !(File (VerificationKey ()) Out)
   , skeyOutFile :: !(File (SigningKey ()) Out)
   }
@@ -45,6 +53,7 @@ data GovernanceCommitteeKeyGenColdCmdArgs era
 data GovernanceCommitteeKeyGenHotCmdArgs era
   = GovernanceCommitteeKeyGenHotCmdArgs
   { era :: !(Exp.Era era)
+  , keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , vkeyOutFile :: !(File (VerificationKey ()) Out)
   , skeyOutFile :: !(File (SigningKey ()) Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Option.hs
@@ -52,7 +52,8 @@ pGovernanceCommitteeKeyGenColdCmd = do
   pCmd w =
     fmap GovernanceCommitteeKeyGenColdCmd $
       GovernanceCommitteeKeyGenColdCmdArgs w
-        <$> pColdVerificationKeyFile
+        <$> pKeyOutputFormat
+        <*> pColdVerificationKeyFile
         <*> pColdSigningKeyFile
 
 pGovernanceCommitteeKeyGenHotCmd
@@ -70,7 +71,8 @@ pGovernanceCommitteeKeyGenHotCmd = do
   pCmd w =
     fmap GovernanceCommitteeKeyGenHotCmd $
       GovernanceCommitteeKeyGenHotCmdArgs w
-        <$> pVerificationKeyFileOut
+        <$> pKeyOutputFormat
+        <*> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
 pGovernanceCommitteeKeyHashCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Run.hs
@@ -34,13 +34,18 @@ import Cardano.CLI.EraIndependent.Hash.Internal.Common (carryHashChecks)
 import Cardano.CLI.EraIndependent.Key.Run qualified as Key
 import Cardano.CLI.Orphan ()
 import Cardano.CLI.Read (readVerificationKeySource)
-import Cardano.CLI.Type.Common (PotentiallyCheckedAnchor (..))
+import Cardano.CLI.Type.Common
+  ( FormatBech32 (..)
+  , FormatTextEnvelope (..)
+  , PotentiallyCheckedAnchor (..)
+  )
 import Cardano.CLI.Type.Key.VerificationKey
 
 import Control.Monad (void)
 import Data.ByteString (ByteString)
 import Data.ByteString.Char8 qualified as BS
 import Data.Function
+import Vary qualified
 
 runGovernanceCommitteeCmds
   :: ()
@@ -63,16 +68,44 @@ runGovernanceCommitteeKeyGenCold
   -> CIO e (VerificationKey CommitteeColdKey, SigningKey CommitteeColdKey)
 runGovernanceCommitteeKeyGenCold
   Cmd.GovernanceCommitteeKeyGenColdCmdArgs
-    { Cmd.vkeyOutFile = vkeyPath
+    { Cmd.keyOutputFormat
+    , Cmd.vkeyOutFile = vkeyPath
     , Cmd.skeyOutFile = skeyPath
     } = do
     skey <- generateSigningKey AsCommitteeColdKey
     let vkey = getVerificationKey skey
 
-    fromEitherIOCli @(FileError ()) $
-      writeLazyByteStringFile skeyPath (textEnvelopeToJSON (Just Key.ccColdSkeyDesc) skey)
-    fromEitherIOCli @(FileError ()) $
-      writeLazyByteStringFile vkeyPath (textEnvelopeToJSON (Just Key.ccColdVkeyDesc) vkey)
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  fromEitherIOCli @(FileError ())
+                    . writeTextFile skeyPath
+                    $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  fromEitherIOCli @(FileError ()) . writeLazyByteStringFile skeyPath $
+                    textEnvelopeToJSON (Just Key.ccColdSkeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
+
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  fromEitherIOCli @(FileError ())
+                    . writeTextFile vkeyPath
+                    $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  fromEitherIOCli @(FileError ()) . writeLazyByteStringFile vkeyPath $
+                    textEnvelopeToJSON (Just Key.ccColdVkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
 
     return (vkey, skey)
 
@@ -81,7 +114,7 @@ runGovernanceCommitteeKeyGenHot
   -> CIO e (VerificationKey CommitteeHotKey, SigningKey CommitteeHotKey)
 runGovernanceCommitteeKeyGenHot
   Cmd.GovernanceCommitteeKeyGenHotCmdArgs
-    { Cmd.era = _eon
+    { Cmd.keyOutputFormat
     , Cmd.vkeyOutFile = vkeyPath
     , Cmd.skeyOutFile = skeyPath
     } = do
@@ -89,12 +122,37 @@ runGovernanceCommitteeKeyGenHot
 
     let vkey = getVerificationKey skey
 
-    fromEitherIOCli @(FileError ()) $
-      writeLazyByteStringFile skeyPath $
-        textEnvelopeToJSON (Just Key.ccHotSkeyDesc) skey
-    fromEitherIOCli @(FileError ()) $
-      writeLazyByteStringFile vkeyPath $
-        textEnvelopeToJSON (Just Key.ccHotVkeyDesc) vkey
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  fromEitherIOCli @(FileError ())
+                    . writeTextFile skeyPath
+                    $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  fromEitherIOCli @(FileError ()) . writeLazyByteStringFile skeyPath $
+                    textEnvelopeToJSON (Just Key.ccHotSkeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
+
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  fromEitherIOCli @(FileError ())
+                    . writeTextFile vkeyPath
+                    $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  fromEitherIOCli @(FileError ()) . writeLazyByteStringFile vkeyPath $
+                    textEnvelopeToJSON (Just Key.ccHotVkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
 
     return (vkey, skey)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
@@ -37,6 +37,7 @@ data GovernanceDRepCmds era
 data GovernanceDRepKeyGenCmdArgs era
   = GovernanceDRepKeyGenCmdArgs
   { era :: !(Exp.Era era)
+  , keyOutputFormat :: !(Vary [FormatBech32, FormatTextEnvelope])
   , vkeyFile :: !(File (VerificationKey ()) Out)
   , skeyFile :: !(File (SigningKey ()) Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
@@ -51,7 +51,8 @@ pGovernanceDRepKeyGenCmd = do
     $ Opt.info
       ( fmap GovernanceDRepKeyGenCmd $
           GovernanceDRepKeyGenCmdArgs Exp.useEra
-            <$> pVerificationKeyFileOut
+            <$> pKeyOutputFormat
+            <*> pVerificationKeyFileOut
             <*> pSigningKeyFileOut
       )
     $ Opt.progDesc "Generate Delegated Representative verification and signing keys."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
@@ -66,15 +66,43 @@ runGovernanceDRepKeyGenCmd
   -> CIO e (VerificationKey DRepKey, SigningKey DRepKey)
 runGovernanceDRepKeyGenCmd
   Cmd.GovernanceDRepKeyGenCmdArgs
-    { vkeyFile
+    { keyOutputFormat
+    , vkeyFile
     , skeyFile
     } = do
     (vkey, skey) <- generateKeyPair AsDRepKey
-    fromEitherIOCli @(FileError ()) $
-      writeLazyByteStringFile skeyFile (textEnvelopeToJSON (Just Key.drepSkeyDesc) skey)
 
-    fromEitherIOCli @(FileError ()) $
-      writeLazyByteStringFile vkeyFile (textEnvelopeToJSON (Just Key.drepVkeyDesc) vkey)
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  fromEitherIOCli @(FileError ())
+                    . writeTextFile skeyFile
+                    $ serialiseToBech32 skey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  fromEitherIOCli @(FileError ()) . writeLazyByteStringFile skeyFile $
+                    textEnvelopeToJSON (Just Key.drepSkeyDesc) skey
+              )
+            $ Vary.exhaustiveCase
+        )
+
+    keyOutputFormat
+      & ( id
+            . Vary.on
+              ( \FormatBech32 ->
+                  fromEitherIOCli @(FileError ())
+                    . writeTextFile vkeyFile
+                    $ serialiseToBech32 vkey
+              )
+            . Vary.on
+              ( \FormatTextEnvelope ->
+                  fromEitherIOCli @(FileError ()) . writeLazyByteStringFile vkeyFile $
+                    textEnvelopeToJSON (Just Key.drepVkeyDesc) vkey
+              )
+            $ Vary.exhaustiveCase
+        )
 
     return (vkey, skey)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1502,12 +1502,21 @@ Usage: cardano-cli conway governance committee
   Committee member commands.
 
 Usage: cardano-cli conway governance committee key-gen-cold 
+                                                              [ --key-output-bech32
+                                                              | --key-output-text-envelope
+                                                              | --key-output-format STRING
+                                                              ]
                                                               --cold-verification-key-file FILEPATH
                                                               --cold-signing-key-file FILEPATH
 
   Create a cold key pair for a Constitutional Committee Member
 
-Usage: cardano-cli conway governance committee key-gen-hot --verification-key-file FILEPATH
+Usage: cardano-cli conway governance committee key-gen-hot 
+                                                             [ --key-output-bech32
+                                                             | --key-output-text-envelope
+                                                             | --key-output-format STRING
+                                                             ]
+                                                             --verification-key-file FILEPATH
                                                              --signing-key-file FILEPATH
 
   Create a hot key pair for a Constitutional Committee Member
@@ -1561,7 +1570,12 @@ Usage: cardano-cli conway governance drep
 
   DRep member commands.
 
-Usage: cardano-cli conway governance drep key-gen --verification-key-file FILEPATH
+Usage: cardano-cli conway governance drep key-gen 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --verification-key-file FILEPATH
                                                     --signing-key-file FILEPATH
 
   Generate Delegated Representative verification and signing keys.
@@ -3906,12 +3920,21 @@ Usage: cardano-cli latest governance committee
   Committee member commands.
 
 Usage: cardano-cli latest governance committee key-gen-cold 
+                                                              [ --key-output-bech32
+                                                              | --key-output-text-envelope
+                                                              | --key-output-format STRING
+                                                              ]
                                                               --cold-verification-key-file FILEPATH
                                                               --cold-signing-key-file FILEPATH
 
   Create a cold key pair for a Constitutional Committee Member
 
-Usage: cardano-cli latest governance committee key-gen-hot --verification-key-file FILEPATH
+Usage: cardano-cli latest governance committee key-gen-hot 
+                                                             [ --key-output-bech32
+                                                             | --key-output-text-envelope
+                                                             | --key-output-format STRING
+                                                             ]
+                                                             --verification-key-file FILEPATH
                                                              --signing-key-file FILEPATH
 
   Create a hot key pair for a Constitutional Committee Member
@@ -3965,7 +3988,12 @@ Usage: cardano-cli latest governance drep
 
   DRep member commands.
 
-Usage: cardano-cli latest governance drep key-gen --verification-key-file FILEPATH
+Usage: cardano-cli latest governance drep key-gen 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --verification-key-file FILEPATH
                                                     --signing-key-file FILEPATH
 
   Generate Delegated Representative verification and signing keys.
@@ -7289,12 +7317,21 @@ Usage: cardano-cli compatible conway governance committee
   Committee member commands.
 
 Usage: cardano-cli compatible conway governance committee key-gen-cold 
+                                                                         [ --key-output-bech32
+                                                                         | --key-output-text-envelope
+                                                                         | --key-output-format STRING
+                                                                         ]
                                                                          --cold-verification-key-file FILEPATH
                                                                          --cold-signing-key-file FILEPATH
 
   Create a cold key pair for a Constitutional Committee Member
 
-Usage: cardano-cli compatible conway governance committee key-gen-hot --verification-key-file FILEPATH
+Usage: cardano-cli compatible conway governance committee key-gen-hot 
+                                                                        [ --key-output-bech32
+                                                                        | --key-output-text-envelope
+                                                                        | --key-output-format STRING
+                                                                        ]
+                                                                        --verification-key-file FILEPATH
                                                                         --signing-key-file FILEPATH
 
   Create a hot key pair for a Constitutional Committee Member
@@ -7348,7 +7385,12 @@ Usage: cardano-cli compatible conway governance drep
 
   DRep member commands.
 
-Usage: cardano-cli compatible conway governance drep key-gen --verification-key-file FILEPATH
+Usage: cardano-cli compatible conway governance drep key-gen 
+                                                               [ --key-output-bech32
+                                                               | --key-output-text-envelope
+                                                               | --key-output-format STRING
+                                                               ]
+                                                               --verification-key-file FILEPATH
                                                                --signing-key-file FILEPATH
 
   Generate Delegated Representative verification and signing keys.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-cold.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-cold.cli
@@ -1,10 +1,22 @@
 Usage: cardano-cli compatible conway governance committee key-gen-cold 
+                                                                         [ --key-output-bech32
+                                                                         | --key-output-text-envelope
+                                                                         | --key-output-format STRING
+                                                                         ]
                                                                          --cold-verification-key-file FILEPATH
                                                                          --cold-signing-key-file FILEPATH
 
   Create a cold key pair for a Constitutional Committee Member
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --cold-verification-key-file FILEPATH
                            Filepath of the cold verification key.
   --cold-signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-hot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-hot.cli
@@ -1,9 +1,22 @@
-Usage: cardano-cli compatible conway governance committee key-gen-hot --verification-key-file FILEPATH
+Usage: cardano-cli compatible conway governance committee key-gen-hot 
+                                                                        [ --key-output-bech32
+                                                                        | --key-output-text-envelope
+                                                                        | --key-output-format STRING
+                                                                        ]
+                                                                        --verification-key-file FILEPATH
                                                                         --signing-key-file FILEPATH
 
   Create a hot key pair for a Constitutional Committee Member
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_key-gen.cli
@@ -1,9 +1,22 @@
-Usage: cardano-cli compatible conway governance drep key-gen --verification-key-file FILEPATH
+Usage: cardano-cli compatible conway governance drep key-gen 
+                                                               [ --key-output-bech32
+                                                               | --key-output-text-envelope
+                                                               | --key-output-format STRING
+                                                               ]
+                                                               --verification-key-file FILEPATH
                                                                --signing-key-file FILEPATH
 
   Generate Delegated Representative verification and signing keys.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_key-gen-cold.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_key-gen-cold.cli
@@ -1,10 +1,22 @@
 Usage: cardano-cli conway governance committee key-gen-cold 
+                                                              [ --key-output-bech32
+                                                              | --key-output-text-envelope
+                                                              | --key-output-format STRING
+                                                              ]
                                                               --cold-verification-key-file FILEPATH
                                                               --cold-signing-key-file FILEPATH
 
   Create a cold key pair for a Constitutional Committee Member
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --cold-verification-key-file FILEPATH
                            Filepath of the cold verification key.
   --cold-signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_key-gen-hot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_key-gen-hot.cli
@@ -1,9 +1,22 @@
-Usage: cardano-cli conway governance committee key-gen-hot --verification-key-file FILEPATH
+Usage: cardano-cli conway governance committee key-gen-hot 
+                                                             [ --key-output-bech32
+                                                             | --key-output-text-envelope
+                                                             | --key-output-format STRING
+                                                             ]
+                                                             --verification-key-file FILEPATH
                                                              --signing-key-file FILEPATH
 
   Create a hot key pair for a Constitutional Committee Member
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_key-gen.cli
@@ -1,9 +1,22 @@
-Usage: cardano-cli conway governance drep key-gen --verification-key-file FILEPATH
+Usage: cardano-cli conway governance drep key-gen 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --verification-key-file FILEPATH
                                                     --signing-key-file FILEPATH
 
   Generate Delegated Representative verification and signing keys.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_committee_key-gen-cold.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_committee_key-gen-cold.cli
@@ -1,10 +1,22 @@
 Usage: cardano-cli latest governance committee key-gen-cold 
+                                                              [ --key-output-bech32
+                                                              | --key-output-text-envelope
+                                                              | --key-output-format STRING
+                                                              ]
                                                               --cold-verification-key-file FILEPATH
                                                               --cold-signing-key-file FILEPATH
 
   Create a cold key pair for a Constitutional Committee Member
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --cold-verification-key-file FILEPATH
                            Filepath of the cold verification key.
   --cold-signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_committee_key-gen-hot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_committee_key-gen-hot.cli
@@ -1,9 +1,22 @@
-Usage: cardano-cli latest governance committee key-gen-hot --verification-key-file FILEPATH
+Usage: cardano-cli latest governance committee key-gen-hot 
+                                                             [ --key-output-bech32
+                                                             | --key-output-text-envelope
+                                                             | --key-output-format STRING
+                                                             ]
+                                                             --verification-key-file FILEPATH
                                                              --signing-key-file FILEPATH
 
   Create a hot key pair for a Constitutional Committee Member
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_key-gen.cli
@@ -1,9 +1,22 @@
-Usage: cardano-cli latest governance drep key-gen --verification-key-file FILEPATH
+Usage: cardano-cli latest governance drep key-gen 
+                                                    [ --key-output-bech32
+                                                    | --key-output-text-envelope
+                                                    | --key-output-format STRING
+                                                    ]
+                                                    --verification-key-file FILEPATH
                                                     --signing-key-file FILEPATH
 
   Generate Delegated Representative verification and signing keys.
 
 Available options:
+  --key-output-bech32      Format key output to BECH32.
+  --key-output-text-envelope
+                           Format key output to TEXT_ENVELOPE (default).
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32". The
+                           --key-output-format flag is deprecated and will be
+                           removed in a future version.
   --verification-key-file FILEPATH
                            Output filepath of the verification key.
   --signing-key-file FILEPATH


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add --key-output-bech32/--key-output-text-envelope to governance key-gen commands
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Closes #1165

The `--key-output-bech32` and `--key-output-text-envelope` flags were added to some key-gen commands but were missing from the governance key-gen commands:
- `cardano-cli <era> governance drep key-gen`
- `cardano-cli <era> governance committee key-gen-cold`
- `cardano-cli <era> governance committee key-gen-hot`

This PR adds the missing output format flags to those commands, making the behaviour consistent across all key-gen commands.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->