### PR TITLE
Bump to cardano-api 11.2.0.0 + migrate to Certificate API

### DIFF
--- a/.changes/20260521_cardano_cli_bump_cardano_api_11_2_0_0.yml
+++ b/.changes/20260521_cardano_cli_bump_cardano_api_11_2_0_0.yml
@@ -1,0 +1,17 @@
+project: cardano-cli
+pr: 1379
+kind:
+  - maintenance
+description: |
+  Bump to cardano-api 11.2.0.0. Folds in three migrations that previously
+  lived in separate PRs / unreleased branches:
+
+  - Companion to cardano-api #1200: drop deprecated TxBody / TxBodyContent
+    uses (was #1375).
+  - Companion to cardano-api #1209: migrate createCompatibleTx, toTxOutInEra,
+    and toTxOutInShelleyBasedEra to the experimental TxOut plus supplemental
+    datum map (was #1376).
+  - Companion to cardano-api #1210: legacy Cardano.Api.Certificate module is
+    gone; migrate all imports to Cardano.Api.Experimental.Certificate /
+    Cardano.Api.Compatible.Certificate as appropriate, and drop vacuous
+    hiding clauses that became -Wdodgy-imports errors under -Werror.

--- a/.changes/20260521_cardano_cli_fix_inline_datum_tx_view.yml
+++ b/.changes/20260521_cardano_cli_fix_inline_datum_tx_view.yml
@@ -1,0 +1,10 @@
+project: cardano-cli
+pr: 1379
+kind:
+  - bugfix
+description: |
+  Fix `cardano-cli transaction view` rendering inline datums as a Haskell-`Show`
+  string instead of the structured JSON detailed-schema dict. The friendly tx
+  renderer's `L.Datum` branch in `friendlyTxOut` now routes through
+  `scriptDataToJson ScriptDataJsonDetailedSchema . fromAlonzoData`, restoring the
+  pre-#1374 output shape for inline-datum outputs.

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2026-04-16T00:15:23Z
-  , cardano-haskell-packages 2026-05-08T13:26:45Z
+  , cardano-haskell-packages 2026-05-18T18:23:40Z
 
 active-repositories:
   , :rest

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -242,7 +242,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=11.1,
+    cardano-api ^>=11.2,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.3,

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance/Command.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.Compatible.Governance.Command
 where
 
 import Cardano.Api
+import Cardano.Api.Compatible.Certificate (MIRPot)
 
 import Cardano.CLI.Compatible.Governance.Types
 import Cardano.CLI.EraBased.Governance.Option

--- a/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
@@ -526,6 +526,10 @@ friendlyTxOut era (Exp.TxOut ledgerTxOut) =
                     , "amount" .= friendlyLedgerValue era ledgerValue
                     , "stake reference"
                         .= friendlyStakeReference (fromShelleyStakeReference stake)
+                    , "datum" .= case ledgerTxOut ^. L.datumTxOutL of
+                        L.NoDatum -> Aeson.Null
+                        L.DatumHash h -> toJSON h
+                        L.Datum bd -> friendlyDatum (L.binaryDataToData bd)
                     , "reference script" .= refScript
                     ]
  where

--- a/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
@@ -33,6 +33,7 @@ where
 import Cardano.Api as Api
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Tx qualified as Exp
 import Cardano.Api.Ledger (ExUnits (..), extractHash, strictMaybeToMaybe)
 import Cardano.Api.Ledger qualified as Alonzo
 import Cardano.Api.Ledger qualified as L
@@ -219,8 +220,7 @@ basePairs
   -> [Aeson.Pair]
 basePairs era body mAuxData =
   Exp.obtainCommonConstraints era $
-    let sbe = convert era :: ShelleyBasedEra era
-        certs = toList (body ^. L.certsTxBodyL)
+    let certs = toList (body ^. L.certsTxBodyL)
      in [ "auxiliary scripts" .= friendlyAuxScripts era mAuxData
         , "certificates"
             .= if null certs
@@ -232,7 +232,7 @@ basePairs era body mAuxData =
         , "metadata" .= friendlyMetadata mAuxData
         , "outputs"
             .= map
-              (friendlyTxOut era . fromCtxUTxOTxOut . fromShelleyTxOut sbe)
+              (friendlyTxOut era . Exp.TxOut)
               (toList (body ^. L.outputsTxBodyL))
         , "withdrawals" .= friendlyWithdrawals (body ^. L.withdrawalsTxBodyL)
         ]
@@ -472,8 +472,7 @@ friendlyReturnCollateral era = \case
   L.SNothing -> Aeson.Null
   L.SJust collOut ->
     Exp.obtainCommonConstraints era $
-      let sbe = convert era :: ShelleyBasedEra era
-       in friendlyTxOut era (fromCtxUTxOTxOut (fromShelleyTxOut sbe collOut))
+      friendlyTxOut era (Exp.TxOut collOut)
 
 friendlyExtraKeyWits :: Set.Set (L.KeyHash L.Guard) -> Aeson.Value
 friendlyExtraKeyWits keyhashes
@@ -499,35 +498,39 @@ friendlyStakeAddress (StakeAddress net cred) =
   , friendlyStakeCredential cred
   ]
 
-friendlyTxOut :: Exp.Era era -> TxOut CtxTx era -> Aeson.Value
-friendlyTxOut era (TxOut addr amount mdatum script) =
+friendlyTxOut
+  :: forall era
+   . Exp.Era era
+  -> Exp.TxOut (Exp.LedgerEra era)
+  -> Aeson.Value
+friendlyTxOut era (Exp.TxOut ledgerTxOut) =
   Exp.obtainCommonConstraints era $
-    object $
-      case addr of
-        AddressInEra ByronAddressInAnyEra byronAdr ->
-          [ "address era" .= String "Byron"
-          , "address" .= serialiseAddress byronAdr
-          , "amount" .= friendlyTxOutValue era amount
-          ]
-        AddressInEra (ShelleyAddressInEra _) saddr@(ShelleyAddress net cred stake) ->
-          let preAlonzo =
+    babbageEraOnwardsConstraints beo $
+      let addr = fromShelleyAddr sbe (ledgerTxOut ^. L.addrTxOutL)
+          ledgerValue = ledgerTxOut ^. L.valueTxOutL
+          refScript = case ledgerTxOut ^. L.referenceScriptTxOutL of
+            L.SNothing -> ReferenceScriptNone
+            L.SJust s -> fromShelleyScriptToReferenceScript sbe s
+       in object $
+            case addr of
+              AddressInEra ByronAddressInAnyEra byronAdr ->
+                [ "address era" .= String "Byron"
+                , "address" .= serialiseAddress byronAdr
+                , "amount" .= friendlyLedgerValue era ledgerValue
+                ]
+              AddressInEra (ShelleyAddressInEra _) saddr@(ShelleyAddress net cred stake) ->
                 friendlyPaymentCredential (fromShelleyPaymentCredential cred)
                   : [ "address era" .= Aeson.String "Shelley"
                     , "network" .= net
                     , "address" .= serialiseAddress saddr
-                    , "amount" .= friendlyTxOutValue era amount
-                    , "stake reference" .= friendlyStakeReference (fromShelleyStakeReference stake)
+                    , "amount" .= friendlyLedgerValue era ledgerValue
+                    , "stake reference"
+                        .= friendlyStakeReference (fromShelleyStakeReference stake)
+                    , "reference script" .= refScript
                     ]
-              datum = ["datum" .= d | d <- maybeToList $ renderDatum mdatum]
-              sinceAlonzo = ["reference script" .= script]
-           in preAlonzo ++ datum ++ sinceAlonzo
  where
-  renderDatum :: TxOutDatum CtxTx era -> Maybe Aeson.Value
-  renderDatum = \case
-    TxOutDatumNone -> Nothing
-    TxOutDatumHash _ h -> Just $ toJSON h
-    TxOutSupplementalDatum _ sData -> Just $ scriptDataToJson ScriptDataJsonDetailedSchema sData
-    TxOutDatumInline _ sData -> Just $ scriptDataToJson ScriptDataJsonDetailedSchema sData
+  beo = convert era :: BabbageEraOnwards era
+  sbe = convert era :: ShelleyBasedEra era
 
 friendlyStakeReference :: StakeAddressReference -> Aeson.Value
 friendlyStakeReference = \case
@@ -689,12 +692,6 @@ friendlyPaymentCredential = \case
 
 friendlyLovelace :: Lovelace -> Aeson.Value
 friendlyLovelace value = String $ docToText (pretty value)
-
-friendlyTxOutValue :: Exp.Era era -> TxOutValue era -> Aeson.Value
-friendlyTxOutValue era = \case
-  TxOutValueByron lovelace -> friendlyLovelace lovelace
-  TxOutValueShelleyBased _ v ->
-    Exp.obtainCommonConstraints era $ friendlyLedgerValue era v
 
 friendlyLedgerValue
   :: ()

--- a/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Json/Friendly.hs
@@ -529,7 +529,9 @@ friendlyTxOut era (Exp.TxOut ledgerTxOut) =
                     , "datum" .= case ledgerTxOut ^. L.datumTxOutL of
                         L.NoDatum -> Aeson.Null
                         L.DatumHash h -> toJSON h
-                        L.Datum bd -> friendlyDatum (L.binaryDataToData bd)
+                        L.Datum bd ->
+                          scriptDataToJson ScriptDataJsonDetailedSchema $
+                            fromAlonzoData (L.binaryDataToData bd)
                     , "reference script" .= refScript
                     ]
  where

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Run.hs
@@ -10,7 +10,7 @@ module Cardano.CLI.Compatible.StakeAddress.Run
   )
 where
 
-import Cardano.Api hiding (makeStakeAddressRegistrationCertificate)
+import Cardano.Api
 import Cardano.Api.Compatible.Certificate
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Command.hs
@@ -10,6 +10,7 @@ module Cardano.CLI.Compatible.StakePool.Command
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental.Certificate (StakePoolMetadataReference, StakePoolRelay)
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
@@ -9,9 +9,10 @@ module Cardano.CLI.Compatible.StakePool.Run
   )
 where
 
-import Cardano.Api hiding (makeStakePoolRegistrationCertificate)
+import Cardano.Api
 import Cardano.Api.Compatible.Certificate
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Certificate (StakePoolParameters (..), toShelleyPoolParams)
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.StakePool.Command

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -38,6 +38,7 @@ import Cardano.CLI.Type.Common
 
 import Control.Monad
 import Data.Map.Ordered.Strict qualified as OMap
+import Data.Map.Strict qualified as Map
 import Lens.Micro
 
 runCompatibleTransactionCmd
@@ -60,7 +61,9 @@ runCompatibleTransactionCmd
     ) = shelleyBasedEraConstraints sbe $ do
     sks <- mapM (fromEitherIOCli . readWitnessSigningData) witnesses
 
-    allOuts <- mapM (toTxOutInAnyEra sbe) outs
+    outsAndDatums <- mapM (toTxOutInAnyEra sbe) outs
+    let allOuts = map fst outsAndDatums
+        extraDatums = Map.unions (map snd outsAndDatums)
 
     certFilesAndMaybeScriptWits <-
       readCertificateScriptWitnesses' sbe certificates
@@ -107,7 +110,7 @@ runCompatibleTransactionCmd
 
     transaction@(ShelleyTx _ ledgerTx) <-
       fromEitherCli $
-        createCompatibleTx sbe ins allOuts fee protocolUpdates votes txCerts
+        createCompatibleTx sbe ins allOuts extraDatums fee protocolUpdates votes txCerts
 
     let txBody = ledgerTx ^. L.bodyTxL
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Run.hs
@@ -61,9 +61,8 @@ runCompatibleTransactionCmd
     ) = shelleyBasedEraConstraints sbe $ do
     sks <- mapM (fromEitherIOCli . readWitnessSigningData) witnesses
 
-    outsAndDatums <- mapM (toTxOutInAnyEra sbe) outs
-    let allOuts = map fst outsAndDatums
-        extraDatums = Map.unions (map snd outsAndDatums)
+    (allOuts, extraDatumsMapList) <- mapAndUnzipM (toTxOutInAnyEra sbe) outs
+    let extraDatums = Map.unions extraDatumsMapList
 
     certFilesAndMaybeScriptWits <-
       readCertificateScriptWitnesses' sbe certificates

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 
@@ -8,28 +10,44 @@ module Cardano.CLI.Compatible.Transaction.TxOut
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental.Tx qualified as Exp
+import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraBased.Script.Read.Common
 import Cardano.CLI.Orphan ()
 import Cardano.CLI.Read
 import Cardano.CLI.Type.Common
+import Cardano.Ledger.Hashes (DataHash)
+import Cardano.Ledger.Plutus.Data qualified as L
+
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 
 toTxOutInAnyEra
   :: ShelleyBasedEra era
   -> TxOutAnyEra
-  -> CIO e (TxOut CtxTx era)
+  -> CIO e (Exp.TxOut (ShelleyLedgerEra era), Map DataHash (L.Data (ShelleyLedgerEra era)))
 toTxOutInAnyEra era (TxOutAnyEra addr' val' mDatumHash refScriptFp) = do
   let addr = anyAddressInShelleyBasedEra era addr'
   mkTxOut era addr val' mDatumHash refScriptFp
 
+-- | Build an output for a transaction body. Produces the experimental
+-- 'Exp.TxOut' plus any supplemental datum bodies that the caller-supplied
+-- datum carries. The legacy 'TxOut CtxTx era' bundled supplemental datums
+-- inside outputs; 'Exp.TxOut' only carries the datum hash, so callers thread
+-- the full datum bodies in separately (e.g. via 'createCompatibleTx').
+--
+-- The legacy 'TxOut CtxTx era' is used internally as a stepping stone to
+-- reuse the api's 'toShelleyTxOutAny' field-level conversion logic; it is
+-- not exposed.
 mkTxOut
   :: ShelleyBasedEra era
   -> AddressInEra era
   -> Value
   -> TxOutDatumAnyEra
   -> ReferenceScriptAnyEra
-  -> CIO e (TxOut CtxTx era)
+  -> CIO e (Exp.TxOut (ShelleyLedgerEra era), Map DataHash (L.Data (ShelleyLedgerEra era)))
 mkTxOut sbe addr val' mDatumHash refScriptFp = do
   let era = toCardanoEra sbe
   val <- toTxOutValueInShelleyBasedEra sbe val'
@@ -46,7 +64,19 @@ mkTxOut sbe addr val' mDatumHash refScriptFp = do
       (`getReferenceScript` refScriptFp)
       era
 
-  pure $ TxOut addr val datum refScript
+  let legacyTxOut = TxOut addr val datum refScript
+  pure $
+    shelleyBasedEraConstraints sbe $
+      (Exp.TxOut (toShelleyTxOutAny sbe legacyTxOut), supplementalsOf datum)
+ where
+  supplementalsOf
+    :: L.Era (ShelleyLedgerEra era)
+    => TxOutDatum CtxTx era
+    -> Map DataHash (L.Data (ShelleyLedgerEra era))
+  supplementalsOf (TxOutSupplementalDatum _ h) =
+    let ld = toAlonzoData h
+     in Map.singleton (L.hashData ld) ld
+  supplementalsOf _ = mempty
 
 toTxOutValueInShelleyBasedEra
   :: ShelleyBasedEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -11,6 +11,12 @@ module Cardano.CLI.EraBased.Common.Option where
 
 import Cardano.Api
 import Cardano.Api.Experimental as Exp
+import Cardano.Api.Experimental.Certificate
+  ( KESPeriod (..)
+  , StakePoolMetadata
+  , StakePoolMetadataReference (..)
+  , StakePoolRelay (..)
+  )
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Network qualified as Consensus
 import Cardano.Api.Parser.Text qualified as P

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/CreateTestnetData/Run.hs
@@ -26,6 +26,10 @@ module Cardano.CLI.EraBased.Genesis.CreateTestnetData.Run
 where
 
 import Cardano.Api hiding (ConwayEra)
+import Cardano.Api.Experimental.Certificate
+  ( KESPeriod (..)
+  , OperationalCertificateIssueCounter (..)
+  )
 import Cardano.Api.Ledger (StandardCrypto, StrictMaybe (SNothing))
 import Cardano.Api.Ledger qualified as L
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
@@ -34,6 +34,12 @@ import Cardano.Api.Byron
   , SigningKey (..)
   )
 import Cardano.Api.Byron qualified as Byron hiding (SigningKey)
+import Cardano.Api.Experimental.Certificate
+  ( KESPeriod (..)
+  , OperationalCertificate
+  , OperationalCertificateIssueCounter (..)
+  , issueOperationalCertificate
+  )
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Byron.Delegation

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Run.hs
@@ -13,11 +13,7 @@ module Cardano.CLI.EraBased.Governance.Committee.Run
   )
 where
 
-import Cardano.Api hiding
-  ( Certificate
-  , makeCommitteeColdkeyResignationCertificate
-  , makeCommitteeHotKeyAuthorizationCertificate
-  )
+import Cardano.Api
 import Cardano.Api.Experimental
   ( Certificate
   , Era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Command.hs
@@ -18,6 +18,7 @@ where
 
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Certificate (DRepMetadata)
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.EraIndependent.Hash.Command (HashGoal)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
@@ -9,6 +9,7 @@ where
 
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Certificate (DRepMetadata, Hash (DRepMetadataHash))
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.EraBased.Common.Option

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Run.hs
@@ -14,13 +14,9 @@ module Cardano.CLI.EraBased.Governance.DRep.Run
   )
 where
 
-import Cardano.Api hiding
-  ( Certificate
-  , makeDrepRegistrationCertificate
-  , makeDrepUnregistrationCertificate
-  , makeDrepUpdateCertificate
-  )
+import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Certificate (DRepMetadata, hashDRepMetadata)
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/GenesisKeyDelegationCertificate/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/GenesisKeyDelegationCertificate/Run.hs
@@ -9,7 +9,7 @@ module Cardano.CLI.EraBased.Governance.GenesisKeyDelegationCertificate.Run
   )
 where
 
-import Cardano.Api hiding (makeGenesisKeyDelegationCertificate)
+import Cardano.Api
 import Cardano.Api.Compatible.Certificate
 
 import Cardano.CLI.Compatible.Exception

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Run.hs
@@ -15,7 +15,7 @@ module Cardano.CLI.EraBased.Governance.Run
   )
 where
 
-import Cardano.Api hiding (makeMIRCertificate)
+import Cardano.Api
 import Cardano.Api.Compatible.Certificate
 import Cardano.Api.Ledger qualified as L
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -41,6 +41,12 @@ import Cardano.Api qualified as Api
 import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Certificate
+  ( OperationalCertificate (..)
+  , PoolId
+  , getKesPeriod
+  , getOpCertCount
+  )
 import Cardano.Api.Experimental.Tx qualified as Exp
 import Cardano.Api.Ledger (strictMaybeToMaybe)
 import Cardano.Api.Ledger qualified as L

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -41,6 +41,7 @@ import Cardano.Api qualified as Api
 import Cardano.Api.Consensus qualified as Consensus
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Tx qualified as Exp
 import Cardano.Api.Ledger (strictMaybeToMaybe)
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Network qualified as Consensus
@@ -67,6 +68,7 @@ import Cardano.CLI.Type.Output qualified as O
 import Cardano.Crypto.Hash (hashToBytesAsHex)
 import Cardano.Ledger.Address qualified as L
 import Cardano.Ledger.Api.State.Query qualified as L
+import Cardano.Ledger.Api.Tx qualified as L
 import Cardano.Ledger.Conway.State (ChainAccountState (..))
 import Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
 import Cardano.Slotting.Time (RelativeTime (..), toRelativeTime)
@@ -1191,7 +1193,7 @@ writeFilteredUTxOs era format mOutFile utxo = do
                   . Vary.on (\FormatCborBin -> CBOR.serialize $ toLedgerUTxO era utxo)
                   . Vary.on (\FormatCborHex -> Base16.encode . CBOR.serialize $ toLedgerUTxO era utxo)
                   . Vary.on (\FormatJson -> Json.encodeJson utxo)
-                  . Vary.on (\FormatText -> strictTextToLazyBytestring $ filteredUTxOsToText utxo)
+                  . Vary.on (\FormatText -> strictTextToLazyBytestring $ filteredUTxOsToText era utxo)
                   . Vary.on (\FormatYaml -> Json.encodeYaml utxo)
                   $ Vary.exhaustiveCase
               )
@@ -1200,29 +1202,33 @@ writeFilteredUTxOs era format mOutFile utxo = do
     . newExceptT
     $ writeLazyByteStringOutput mOutFile output
 
-filteredUTxOsToText :: UTxO era -> Text
-filteredUTxOsToText (UTxO utxo) = do
-  mconcat
-    [ Text.unlines [title, Text.replicate (Text.length title + 2) "-"]
-    , Text.unlines $
-        map utxoToText $
-          toList utxo
-    ]
+filteredUTxOsToText :: ShelleyBasedEra era -> UTxO era -> Text
+filteredUTxOsToText sbe utxo =
+  shelleyBasedEraConstraints sbe $
+    let entries =
+          [ (fromShelleyTxIn ledgerTxIn, Exp.TxOut ledgerTxOut)
+          | (ledgerTxIn, ledgerTxOut) <- Map.toList . L.unUTxO $ toLedgerUTxO sbe utxo
+          ]
+     in mconcat
+          [ Text.unlines [title, Text.replicate (Text.length title + 2) "-"]
+          , Text.unlines $ map (utxoToText sbe) entries
+          ]
  where
   title :: Text
   title =
     "                           TxHash                                 TxIx        Amount"
 
 utxoToText
-  :: (TxIn, TxOut CtxUTxO era)
+  :: ShelleyBasedEra era
+  -> (TxIn, Exp.TxOut (ShelleyLedgerEra era))
   -> Text
-utxoToText txInOutTuple =
-  let (TxIn (TxId txhash) (TxIx index), TxOut _ value mDatum _) = txInOutTuple
-   in mconcat
-        [ Text.decodeLatin1 (hashToBytesAsHex txhash)
-        , textShowN 6 index
-        , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
-        ]
+utxoToText sbe (TxIn (TxId txhash) (TxIx index), Exp.TxOut ledgerTxOut) =
+  shelleyBasedEraConstraints sbe $
+    mconcat
+      [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+      , textShowN 6 index
+      , "        " <> printableValue <> " + " <> printableDatum
+      ]
  where
   textShowN :: Show a => Int -> a -> Text
   textShowN len x =
@@ -1230,10 +1236,19 @@ utxoToText txInOutTuple =
         slen = length str
      in Text.pack $ replicate (max 1 (len - slen)) ' ' ++ str
 
-  printableValue :: TxOutValue era -> Text
-  printableValue = \case
-    TxOutValueByron (L.Coin i) -> Text.pack $ show i
-    TxOutValueShelleyBased sbe2 val -> renderValue $ Api.fromLedgerValue sbe2 val
+  printableValue :: Text
+  printableValue =
+    renderValue $ Api.fromLedgerValue sbe (ledgerTxOut ^. L.valueTxOutL)
+
+  -- Debug-style datum rendering — pre-Babbage outputs have no datum
+  -- representation we can read uniformly, so show the babbage+ ledger
+  -- datum where it exists and an empty placeholder otherwise.
+  printableDatum :: Text
+  printableDatum =
+    caseShelleyToAlonzoOrBabbageEraOnwards
+      (const "")
+      (\beo -> babbageEraOnwardsConstraints beo $ Text.pack $ show (ledgerTxOut ^. L.datumTxOutL))
+      sbe
 
 runQueryStakePoolsCmd
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
@@ -20,7 +20,7 @@ module Cardano.CLI.EraBased.StakeAddress.Run
   )
 where
 
-import Cardano.Api hiding (makeStakeAddressRegistrationCertificate)
+import Cardano.Api
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger qualified as L

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
@@ -15,6 +15,11 @@ where
 
 import Cardano.Api
 import Cardano.Api.Experimental qualified as Exp
+import Cardano.Api.Experimental.Certificate
+  ( StakePoolMetadata
+  , StakePoolMetadataReference
+  , StakePoolRelay
+  )
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.EraIndependent.Hash.Command (HashGoal)

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Internal/Metadata.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Internal/Metadata.hs
@@ -4,6 +4,10 @@ module Cardano.CLI.EraBased.StakePool.Internal.Metadata
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental.Certificate
+  ( StakePoolMetadataReference (..)
+  , validateAndHashStakePoolMetadata
+  )
 
 import Cardano.CLI.EraIndependent.Hash.Internal.Common hiding (carryHashChecks)
 import Cardano.CLI.Type.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
@@ -10,6 +10,7 @@ where
 
 import Cardano.Api
 import Cardano.Api.Experimental
+import Cardano.Api.Experimental.Certificate (Hash (StakePoolMetadataHash), StakePoolMetadata)
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Environment (EnvCli (..))

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Run.hs
@@ -16,12 +16,14 @@ module Cardano.CLI.EraBased.StakePool.Run
   )
 where
 
-import Cardano.Api hiding
-  ( Certificate
-  , makeStakePoolRegistrationCertificate
-  , makeStakePoolRetirementCertificate
-  )
+import Cardano.Api
 import Cardano.Api.Experimental
+import Cardano.Api.Experimental.Certificate
+  ( StakePoolMetadata
+  , StakePoolParameters (..)
+  , toShelleyPoolParams
+  , validateAndHashStakePoolMetadata
+  )
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -37,6 +37,7 @@ import Cardano.Api hiding
   )
 import Cardano.Api qualified as Api
 import Cardano.Api.Byron qualified as Byron
+import Cardano.Api.Compatible (addWitnesses)
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Experimental.AnyScriptWitness qualified as Exp
@@ -1258,17 +1259,18 @@ runTransactionSignCmd
 
         InAnyShelleyBasedEra sbe tx@(ShelleyTx _ ledgerTx) <- pure anyTx
 
-        let (apiTxBody, existingTxKeyWits) = getTxBodyAndWitnesses tx
+        let existingTxKeyWits = getTxWitnesses tx
+            ledgerTxBody = shelleyBasedEraConstraints sbe $ ledgerTx ^. L.bodyTxL
 
         byronWitnesses <-
           firstExceptT TxCmdBootstrapWitnessError . liftEither $
             forM sksByron $
               shelleyBasedEraConstraints sbe $
-                mkShelleyBootstrapWitness sbe mNetworkId (ledgerTx ^. L.bodyTxL)
+                mkShelleyBootstrapWitness sbe mNetworkId ledgerTxBody
 
-        let newShelleyKeyWits = map (makeShelleyKeyWitness sbe apiTxBody) sksShelley
+        let newShelleyKeyWits = map (makeShelleyKeyWitness' sbe ledgerTxBody) sksShelley
             allKeyWits = existingTxKeyWits ++ newShelleyKeyWits ++ byronWitnesses
-            signedTx = makeSignedTransaction allKeyWits apiTxBody
+            signedTx = addWitnesses allKeyWits tx
 
         modifyError TxCmdWriteFileError $
           hoistIOEither $
@@ -1282,8 +1284,9 @@ runTransactionSignCmd
             readFileTxBody txbodyFile
 
         case unwitnessed of
-          IncompleteTxBody anyTxBody -> do
-            InAnyShelleyBasedEra sbe txbody@(ShelleyTxBody _ ledgerTxBody _ _ _ _) <- pure anyTxBody
+          IncompleteTxBody sbe (Exp.UnsignedTx ledgerTx) -> do
+            let ledgerTxBody = shelleyBasedEraConstraints sbe $ ledgerTx ^. L.bodyTxL
+                unsignedTxAsTx = shelleyBasedEraConstraints sbe $ ShelleyTx sbe ledgerTx
 
             -- Byron witnesses require the network ID. This can either be provided
             -- directly or derived from a provided Byron address.
@@ -1292,8 +1295,8 @@ runTransactionSignCmd
                 forM sksByron $
                   mkShelleyBootstrapWitness sbe mNetworkId ledgerTxBody
 
-            let shelleyKeyWitnesses = map (makeShelleyKeyWitness sbe txbody) sksShelley
-                tx = makeSignedTransaction (byronWitnesses ++ shelleyKeyWitnesses) txbody
+            let shelleyKeyWitnesses = map (makeShelleyKeyWitness' sbe ledgerTxBody) sksShelley
+                tx = addWitnesses (byronWitnesses ++ shelleyKeyWitnesses) unsignedTxAsTx
 
             modifyError TxCmdWriteFileError $
               hoistIOEither $
@@ -1315,14 +1318,19 @@ runTransactionSubmitCmd
     , txFile
     } = do
     txFileOrPipe <- liftIO $ fileOrPipe txFile
-    InAnyShelleyBasedEra era tx <-
+    InAnyShelleyBasedEra era tx@(ShelleyTx _ ledgerTx) <-
       lift (readFileTx txFileOrPipe) & onLeft (left . TxCmdTextEnvError)
     let txInMode = TxInMode era tx
     res <- liftIO $ submitTxToNodeLocal nodeConnInfo txInMode
     case res of
       TxSubmitSuccess -> do
         liftIO $ Text.hPutStrLn IO.stderr "Transaction successfully submitted. Transaction hash is:"
-        liftIO $ LBS.putStrLn $ Aeson.encode $ TxSubmissionResult $ getTxId $ getTxBody tx
+        liftIO $
+          LBS.putStrLn $
+            Aeson.encode $
+              TxSubmissionResult $
+                shelleyBasedEraConstraints era $
+                  getTxIdShelley era (ledgerTx ^. L.bodyTxL)
       TxSubmitFail reason ->
         case reason of
           TxValidationErrorInCardanoMode err -> left . TxCmdTxSubmitError . Text.pack $ show err
@@ -1348,27 +1356,31 @@ runTransactionCalculateMinFeeCmd
     , outFile
     } = do
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-    unwitnessed <-
+    IncompleteTxBody (sbe :: ShelleyBasedEra era) (Exp.UnsignedTx ledgerTx) <-
       fromEitherIOCli $
         readFileTxBody txbodyFile
 
-    let nShelleyKeyWitW32 = fromIntegral nShelleyKeyWitnesses
-
-    InAnyShelleyBasedEra sbe txbody <- pure $ unIncompleteTxBody unwitnessed
+    let nShelleyKeyWitW32 :: Word
+        nShelleyKeyWitW32 = fromIntegral nShelleyKeyWitnesses
 
     era <- fromEitherCli $ Exp.sbeToEra sbe
-    lpparams <-
+    (lpparams :: L.PParams (Exp.LedgerEra era)) <-
       fromExceptTCli @ProtocolParamsError $
         Exp.obtainCommonConstraints era $
           readProtocolParameters protocolParamsFile
 
-    let shelleyfee = evaluateTransactionFee sbe lpparams txbody nShelleyKeyWitW32 0 sReferenceScript
-
-    let byronfee =
-          shelleyBasedEraConstraints sbe $
-            calculateByronWitnessFees (lpparams ^. L.ppTxFeePerByteL) nByronKeyWitnesses
-
-    let fee = shelleyfee + byronfee
+    let unsignedTx :: Exp.UnsignedTx (Exp.LedgerEra era)
+        unsignedTx = obtainCommonConstraints era $ Exp.UnsignedTx ledgerTx
+        shelleyfee :: Lovelace
+        shelleyfee =
+          obtainCommonConstraints era $
+            Exp.evaluateTransactionFee lpparams unsignedTx nShelleyKeyWitW32 0 sReferenceScript
+        txFeePerByte :: L.CoinPerByte
+        txFeePerByte = obtainCommonConstraints era $ lpparams ^. L.ppTxFeePerByteL
+        byronfee :: Lovelace
+        byronfee = calculateByronWitnessFees txFeePerByte nByronKeyWitnesses
+        fee :: Lovelace
+        fee = shelleyfee + byronfee
         textToWrite = docToText $ pretty fee
         content = Aeson.object ["fee" .= fee]
 
@@ -1539,7 +1551,7 @@ runTransactionCalculatePlutusScriptCostCmd
       -> UTxO era
       -> Tx era
       -> ExceptT TxCmdError IO ()
-    calculatePlutusScriptsCosts aeo systemStart eraHistory pparams txEraUtxo tx = do
+    calculatePlutusScriptsCosts aeo systemStart eraHistory pparams txEraUtxo tx@(ShelleyTx sbe ledgerTx) = do
       let era' = toCardanoEra aeo
 
       let scriptHashes = collectPlutusScriptHashes aeo tx txEraUtxo
@@ -1548,13 +1560,13 @@ runTransactionCalculatePlutusScriptCostCmd
         pure (getExecutionUnitPrices era' pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
 
       let scriptExecUnitsMap =
-            evaluateTransactionExecutionUnits
-              era'
+            evaluateTransactionExecutionUnitsShelley
+              sbe
               systemStart
               (toLedgerEpochInfo eraHistory)
               pparams
               txEraUtxo
-              (getTxBody tx)
+              ledgerTx
 
       scriptCostOutput <-
         firstExceptT TxCmdPlutusScriptCostErr $
@@ -1663,20 +1675,19 @@ runTransactionTxIdCmd
     { inputTxBodyOrTxFile
     , outputFormat
     } = do
-    InAnyShelleyBasedEra _era txbody <-
+    txId <-
       case inputTxBodyOrTxFile of
         InputTxBodyFile (File txbodyFilePath) -> do
           txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-          unwitnessed <-
+          IncompleteTxBody sbe (Exp.UnsignedTx ledgerTx) <-
             firstExceptT TxCmdTextEnvError . newExceptT $
               readFileTxBody txbodyFile
-          return $ unIncompleteTxBody unwitnessed
+          return $ shelleyBasedEraConstraints sbe $ getTxIdShelley sbe (ledgerTx ^. L.bodyTxL)
         InputTxFile (File txFilePath) -> do
           txFile <- liftIO $ fileOrPipe txFilePath
-          InAnyShelleyBasedEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdTextEnvError)
-          return . InAnyShelleyBasedEra era $ getTxBody tx
-
-    let txId = getTxId txbody
+          InAnyShelleyBasedEra era (ShelleyTx _ ledgerTx) <-
+            lift (readFileTx txFile) & onLeft (left . TxCmdTextEnvError)
+          return $ shelleyBasedEraConstraints era $ getTxIdShelley era (ledgerTx ^. L.bodyTxL)
 
     liftIO $
       outputFormat
@@ -1703,28 +1714,26 @@ runTransactionWitnessCmd
     , outFile
     } = do
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-    unwitnessed <-
+    IncompleteTxBody sbe (Exp.UnsignedTx ledgerTx) <-
       firstExceptT TxCmdTextEnvError . newExceptT $
         readFileTxBody txbodyFile
-    case unwitnessed of
-      IncompleteTxBody anyTxBody -> do
-        InAnyShelleyBasedEra sbe txbody@(ShelleyTxBody _ ledgerTxBody _ _ _ _) <- pure anyTxBody
-        someWit <-
-          firstExceptT TxCmdReadWitnessSigningDataError
-            . newExceptT
-            $ readWitnessSigningData witnessSigningData
-        witness <-
-          case categoriseSomeSigningWitness someWit of
-            -- Byron witnesses require the network ID. This can either be provided
-            -- directly or derived from a provided Byron address.
-            AByronWitness bootstrapWitData ->
-              firstExceptT TxCmdBootstrapWitnessError . liftEither $
-                mkShelleyBootstrapWitness sbe mNetworkId ledgerTxBody bootstrapWitData
-            AShelleyKeyWitness skShelley ->
-              pure $ makeShelleyKeyWitness sbe txbody skShelley
+    let ledgerTxBody = shelleyBasedEraConstraints sbe $ ledgerTx ^. L.bodyTxL
+    someWit <-
+      firstExceptT TxCmdReadWitnessSigningDataError
+        . newExceptT
+        $ readWitnessSigningData witnessSigningData
+    witness <-
+      case categoriseSomeSigningWitness someWit of
+        -- Byron witnesses require the network ID. This can either be provided
+        -- directly or derived from a provided Byron address.
+        AByronWitness bootstrapWitData ->
+          firstExceptT TxCmdBootstrapWitnessError . liftEither $
+            mkShelleyBootstrapWitness sbe mNetworkId ledgerTxBody bootstrapWitData
+        AShelleyKeyWitness skShelley ->
+          pure $ makeShelleyKeyWitness' sbe ledgerTxBody skShelley
 
-        firstExceptT TxCmdWriteFileError . newExceptT $
-          writeTxWitnessFileTextEnvelope sbe outFile witness
+    firstExceptT TxCmdWriteFileError . newExceptT $
+      writeTxWitnessFileTextEnvelope sbe outFile witness
 
 runTransactionSignWitnessCmd
   :: ()
@@ -1739,7 +1748,7 @@ runTransactionSignWitnessCmd
     } = do
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
     -- unwitnessed body
-    IncompleteTxBody (InAnyShelleyBasedEra era txbody) <-
+    IncompleteTxBody era (Exp.UnsignedTx ledgerTx) <-
       lift (readFileTxBody txbodyFile) & onLeft (left . TxCmdTextEnvError)
     witnesses <-
       sequence
@@ -1759,7 +1768,8 @@ runTransactionSignWitnessCmd
         | witnessFile@(WitnessFile file) <- witnessFiles
         ]
 
-    let tx = makeSignedTransaction witnesses txbody
+    let unsignedTxAsTx = shelleyBasedEraConstraints era $ ShelleyTx era ledgerTx
+        tx = addWitnesses witnesses unsignedTxAsTx
     modifyError TxCmdWriteFileError $
       hoistIOEither $
         if isCborOutCanonical == TxCborCanonical

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -1288,8 +1288,8 @@ runTransactionSignCmd
 
         case unwitnessed of
           IncompleteTxBody sbe (Exp.UnsignedTx ledgerTx) -> do
-            let ledgerTxBody = shelleyBasedEraConstraints sbe $ ledgerTx ^. L.bodyTxL
-                unsignedTxAsTx = shelleyBasedEraConstraints sbe $ ShelleyTx sbe ledgerTx
+            let ledgerTxBody = ledgerTx ^. L.bodyTxL
+                unsignedTxAsTx = ShelleyTx sbe ledgerTx
 
             -- Byron witnesses require the network ID. This can either be provided
             -- directly or derived from a provided Byron address.
@@ -1326,14 +1326,13 @@ runTransactionSubmitCmd
     let txInMode = TxInMode era tx
     res <- liftIO $ submitTxToNodeLocal nodeConnInfo txInMode
     case res of
-      TxSubmitSuccess -> do
-        liftIO $ Text.hPutStrLn IO.stderr "Transaction successfully submitted. Transaction hash is:"
-        liftIO $
-          LBS.putStrLn $
-            Aeson.encode $
-              TxSubmissionResult $
-                shelleyBasedEraConstraints era $
-                  getTxIdShelley era (ledgerTx ^. L.bodyTxL)
+      TxSubmitSuccess -> liftIO $ do
+        Text.hPutStrLn IO.stderr "Transaction successfully submitted. Transaction hash is:"
+        LBS.putStrLn $
+          Aeson.encode $
+            TxSubmissionResult $
+              shelleyBasedEraConstraints era $
+                getTxIdShelley era (ledgerTx ^. L.bodyTxL)
       TxSubmitFail reason ->
         case reason of
           TxValidationErrorInCardanoMode err -> left . TxCmdTxSubmitError . Text.pack $ show err
@@ -1374,16 +1373,21 @@ runTransactionCalculateMinFeeCmd
 
     let unsignedTx :: Exp.UnsignedTx (Exp.LedgerEra era)
         unsignedTx = obtainCommonConstraints era $ Exp.UnsignedTx ledgerTx
+
         shelleyfee :: Lovelace
         shelleyfee =
           obtainCommonConstraints era $
             Exp.evaluateTransactionFee lpparams unsignedTx nShelleyKeyWitW32 0 sReferenceScript
+
         txFeePerByte :: L.CoinPerByte
         txFeePerByte = obtainCommonConstraints era $ lpparams ^. L.ppTxFeePerByteL
+
         byronfee :: Lovelace
         byronfee = calculateByronWitnessFees txFeePerByte nByronKeyWitnesses
+
         fee :: Lovelace
         fee = shelleyfee + byronfee
+
         textToWrite = docToText $ pretty fee
         content = Aeson.object ["fee" .= fee]
 
@@ -1720,7 +1724,7 @@ runTransactionWitnessCmd
     IncompleteTxBody sbe (Exp.UnsignedTx ledgerTx) <-
       firstExceptT TxCmdTextEnvError . newExceptT $
         readFileTxBody txbodyFile
-    let ledgerTxBody = shelleyBasedEraConstraints sbe $ ledgerTx ^. L.bodyTxL
+    let ledgerTxBody = ledgerTx ^. L.bodyTxL
     someWit <-
       firstExceptT TxCmdReadWitnessSigningDataError
         . newExceptT
@@ -1771,7 +1775,7 @@ runTransactionSignWitnessCmd
         | witnessFile@(WitnessFile file) <- witnessFiles
         ]
 
-    let unsignedTxAsTx = shelleyBasedEraConstraints era $ ShelleyTx era ledgerTx
+    let unsignedTxAsTx = ShelleyTx era ledgerTx
         tx = addWitnesses witnesses unsignedTxAsTx
     modifyError TxCmdWriteFileError $
       hoistIOEither $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -29,8 +29,7 @@ module Cardano.CLI.EraBased.Transaction.Run
 where
 
 import Cardano.Api hiding
-  ( Certificate
-  , mkTxCertificates
+  ( mkTxCertificates
   , txId
   , validateTxIns
   , validateTxInsCollateral
@@ -41,6 +40,7 @@ import Cardano.Api.Compatible (addWitnesses)
 import Cardano.Api.Experimental (obtainCommonConstraints)
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Experimental.AnyScriptWitness qualified as Exp
+import Cardano.Api.Experimental.Certificate (PoolId)
 import Cardano.Api.Experimental.Tx qualified as Exp
 import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Network qualified as Consensus

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -367,13 +367,15 @@ runTransactionBuildCmd
           else writeTxFileTextEnvelope eon fpath noWitTx
 
 toTxOutInEra
-  :: Exp.IsEra era
+  :: forall era e
+   . Exp.IsEra era
   => TxOutAnyEra
   -> CIO e (Exp.TxOut (Exp.LedgerEra era), Map.Map DataHash (L.Data (Exp.LedgerEra era)))
 toTxOutInEra (TxOutAnyEra addr' val' mDatumHash refScriptFp) = do
-  let addr = anyAddressInShelleyBasedEra (convert Exp.useEra) addr'
-  o <- mkTxOut (convert Exp.useEra) addr val' mDatumHash refScriptFp
-  fromEitherCli $ Exp.fromLegacyTxOut o
+  let sbe = convert (Exp.useEra @era)
+      addr = anyAddressInShelleyBasedEra sbe addr'
+  obtainCommonConstraints (Exp.useEra @era) $
+    mkTxOut sbe addr val' mDatumHash refScriptFp
 
 runTransactionBuildEstimateCmd
   :: forall era e
@@ -1177,14 +1179,15 @@ getAllReferenceInputs
       ]
 
 toTxOutInShelleyBasedEra
-  :: Exp.IsEra era
+  :: forall era e
+   . Exp.IsEra era
   => TxOutShelleyBasedEra
   -> CIO e (Exp.TxOut (Exp.LedgerEra era), Map.Map DataHash (L.Data (Exp.LedgerEra era)))
 toTxOutInShelleyBasedEra (TxOutShelleyBasedEra addr' val' mDatumHash refScriptFp) = do
-  let sbe = convert Exp.useEra
+  let sbe = convert (Exp.useEra @era)
       addr = shelleyAddressInEra sbe addr'
-  o <- mkTxOut sbe addr val' mDatumHash refScriptFp
-  fromEitherCli $ Exp.fromLegacyTxOut o
+  obtainCommonConstraints (Exp.useEra @era) $
+    mkTxOut sbe addr val' mDatumHash refScriptFp
 
 -- TODO: Currently we specify the policyId with the '--mint' option on the cli
 -- and we added a separate '--policy-id' parser that parses the policy id for the

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/TransactionView/Run.hs
@@ -37,19 +37,15 @@ runTransactionViewCmd
     case inputTxBodyOrTxFile of
       InputTxBodyFile (File txbodyFilePath) -> do
         txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-        unwitnessed <-
-          fromEitherIOCli $
-            readFileTxBody txbodyFile
-        InAnyShelleyBasedEra (sbe :: ShelleyBasedEra era) txbody <-
-          pure $ unIncompleteTxBody unwitnessed
+        IncompleteTxBody (sbe :: ShelleyBasedEra era) (Exp.UnsignedTx ledgerTx) <-
+          fromEitherIOCli $ readFileTxBody txbodyFile
         era <- fromEitherCli (Exp.sbeToEra sbe)
         -- Why are we differentiating between a transaction body and a transaction?
-        -- In the case of a transaction body, we /could/ simply call @makeSignedTransaction []@
+        -- In the case of a transaction body, we /could/ simply call @addWitnesses []@
         -- to get a transaction which would allow us to reuse friendlyTxBS. However,
         -- this would mean that we'd have an empty list of witnesses mentioned in the output, which
         -- is arguably not part of the transaction body.
-        let ShelleyTx _ ledgerTx = makeSignedTransaction [] txbody
-            unsignedTx :: Exp.UnsignedTx (Exp.LedgerEra era)
+        let unsignedTx :: Exp.UnsignedTx (Exp.LedgerEra era)
             unsignedTx = Exp.obtainCommonConstraints era $ Exp.UnsignedTx ledgerTx
         fromEitherIOCli @(FileError ()) $
           friendlyTxBody outputFormat mOutFile era unsignedTx

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Command.hs
@@ -18,6 +18,7 @@ module Cardano.CLI.EraIndependent.Node.Command
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental.Certificate (KESPeriod)
 
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Key

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Run.hs
@@ -19,6 +19,10 @@ module Cardano.CLI.EraIndependent.Node.Run
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental.Certificate
+  ( OperationalCertificateIssueCounter (..)
+  , issueOperationalCertificate
+  )
 
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.EraIndependent.Node.Command qualified as Cmd

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -303,8 +303,12 @@ readFileTx file = do
       InAnyShelleyBasedEra sbe tx <- pure cddlTx
       return $ Right $ inAnyShelleyBasedEra sbe tx
 
-newtype IncompleteTxBody
-  = IncompleteTxBody {unIncompleteTxBody :: InAnyShelleyBasedEra TxBody}
+data IncompleteTxBody where
+  IncompleteTxBody
+    :: IsShelleyBasedEra era
+    => ShelleyBasedEra era
+    -> Exp.UnsignedTx (ShelleyLedgerEra era)
+    -> IncompleteTxBody
 
 readFileTxBody :: FileOrPipe -> IO (Either (FileError TextEnvelopeError) IncompleteTxBody)
 readFileTxBody file = do
@@ -312,8 +316,8 @@ readFileTxBody file = do
   case cddlTxOrErr of
     Left e -> return $ Left e
     Right cddlTx -> do
-      InAnyShelleyBasedEra sbe tx <- pure cddlTx
-      return $ Right $ IncompleteTxBody $ inAnyShelleyBasedEra sbe $ getTxBody tx
+      InAnyShelleyBasedEra sbe (ShelleyTx _ ledgerTx) <- pure cddlTx
+      return $ Right $ shelleyBasedEraConstraints sbe $ IncompleteTxBody sbe (Exp.UnsignedTx ledgerTx)
 
 readTx :: FileOrPipe -> IO (Either (FileError TextEnvelopeError) (InAnyShelleyBasedEra Tx))
 readTx =

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -115,7 +115,6 @@ import Cardano.CLI.Type.Governance
 import Cardano.CLI.Type.Key
 import Cardano.Crypto.Hash qualified as Crypto
 import Cardano.Ledger.Api qualified as L
-import Cardano.Ledger.Core qualified as L
 
 import RIO (readFileBinary)
 import Prelude

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -105,6 +105,7 @@ module Cardano.CLI.Type.Common
 where
 
 import Cardano.Api hiding (Script)
+import Cardano.Api.Experimental.Certificate (DRepMetadata, StakePoolMetadata)
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.Ledger.Api.State.Query qualified as L

--- a/cardano-cli/src/Cardano/CLI/Type/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Common.hs
@@ -498,7 +498,9 @@ data EpochLeadershipSchedule
   | NextEpoch
   deriving Show
 
-type TxBodyFile = File (TxBody ())
+data TxBodyTag
+
+type TxBodyFile = File TxBodyTag
 
 type TxFile = File (Tx ())
 

--- a/cardano-cli/src/Cardano/CLI/Type/Error/GovernanceCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/GovernanceCmdError.hs
@@ -5,6 +5,7 @@
 module Cardano.CLI.Type.Error.GovernanceCmdError where
 
 import Cardano.Api
+import Cardano.Api.Experimental.Certificate (DRepMetadata, Hash (DRepMetadataHash))
 
 data GovernanceCmdError
   = -- Voting related

--- a/cardano-cli/src/Cardano/CLI/Type/Error/StakePoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/StakePoolCmdError.hs
@@ -9,6 +9,11 @@ module Cardano.CLI.Type.Error.StakePoolCmdError
 where
 
 import Cardano.Api
+import Cardano.Api.Experimental.Certificate
+  ( Hash (StakePoolMetadataHash)
+  , StakePoolMetadata
+  , StakePoolMetadataValidationError
+  )
 
 import Cardano.CLI.Type.Error.HashCmdError (FetchURLError)
 

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TxCmdError.hs
@@ -42,7 +42,6 @@ data AnyTxBodyErrorAutoBalance where
 
 data TxCmdError
   = TxCmdCBORDecodeError !CBOR.DecoderError
-  | TxCmdDatumDecodingError Exp.DatumDecodingError
   | TxCmdProtocolParamsError ProtocolParamsError
   | forall era. LostScriptWitnesses
       [Exp.AnyIndexedPlutusScriptWitness (Exp.LedgerEra era)]
@@ -199,8 +198,6 @@ renderTxCmdError = \case
       , pretty (length after)
       , "."
       ]
-  TxCmdDatumDecodingError err ->
-    "Error decoding datum: " <> pshow err
 
 prettyPolicyIdList :: [PolicyId] -> Doc ann
 prettyPolicyIdList =

--- a/cardano-cli/src/Cardano/CLI/Type/Error/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/TxValidationError.hs
@@ -13,7 +13,6 @@ module Cardano.CLI.Type.Error.TxValidationError
   , validateScriptSupportedInEra
   , validateTxAuxScripts
   , validateRequiredSigners
-  , validateTxReturnCollateral
   , validateTxScriptValidity
   , validateTxTotalCollateral
   , validateTxValidityLowerBound
@@ -87,14 +86,6 @@ validateTxTreasuryDonation mTreasuryDonation = do
   TxTreasuryDonation{unTxTreasuryDonation} <- mTreasuryDonation
 
   Exp.obtainCommonConstraints (Exp.useEra @era) $ mkFeatured unTxTreasuryDonation
-
-validateTxReturnCollateral
-  :: IsEra era
-  => Maybe (TxOut CtxTx era)
-  -> TxReturnCollateral CtxTx era
-validateTxReturnCollateral Nothing = TxReturnCollateralNone
-validateTxReturnCollateral (Just retColTxOut) = do
-  TxReturnCollateral (convert useEra) retColTxOut
 
 validateTxValidityLowerBound
   :: IsEra era

--- a/cardano-cli/src/Cardano/CLI/Type/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Key.hs
@@ -48,6 +48,7 @@ where
 
 import Cardano.Api
 import Cardano.Api.Byron (ByronKey)
+import Cardano.Api.Experimental.Certificate (StakePoolMetadataReference, StakePoolRelay)
 import Cardano.Api.Ledger qualified as L
 
 import Cardano.CLI.Compatible.Exception

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
@@ -2,7 +2,8 @@
 
 module Test.Golden.Shelley.TextEnvelope.Certificates.Operational where
 
-import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (HasTextEnvelope (..))
+import Cardano.Api.Experimental.Certificate (AsType (AsOperationalCertificate))
 
 import Control.Monad (void)
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -3,6 +3,7 @@
 module Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys where
 
 import Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api.Experimental.Certificate (AsType (AsOperationalCertificateIssueCounter))
 
 import Control.Monad (void)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view-metadata-detailedschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view-metadata-detailedschema.out
@@ -28,6 +28,7 @@ outputs:
   address era: Shelley
   amount:
     lovelace: 24910487859
+  datum: null
   network: Testnet
   payment credential key hash: 52e63f22c5107ed776b70f7b92248b02552fd08f3e747bc745099441
   reference script: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view-metadata-noschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view-metadata-noschema.out
@@ -61,6 +61,7 @@ outputs:
   address era: Shelley
   amount:
     lovelace: 24910487859
+  datum: null
   network: Testnet
   payment credential key hash: 52e63f22c5107ed776b70f7b92248b02552fd08f3e747bc745099441
   reference script: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view.json
@@ -19,6 +19,7 @@
             "amount": {
                 "lovelace": 5000000
             },
+            "datum": null,
             "network": "Mainnet",
             "payment credential key hash": "4ff4ae7c2e65fc82423ce3514dc5d62984ea4b2f4756e7d6b15e8169",
             "reference script": null,

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view.out
@@ -753,6 +753,7 @@ outputs:
       asset 736e6f77 (snow): 138
       asset f00d: 134
       default asset: 130
+  datum: null
   network: Testnet
   payment credential key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313
   reference script: null
@@ -798,6 +799,7 @@ return collateral:
   address era: Shelley
   amount:
     lovelace: 200
+  datum: null
   network: Testnet
   payment credential key hash: f2998eb67942c4674d01e2cd435e1f17919e095eec43807bb0010313
   reference script: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view.yaml
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/transaction-view.yaml
@@ -15,6 +15,7 @@ outputs:
   address era: Shelley
   amount:
     lovelace: 5000000
+  datum: null
   network: Mainnet
   payment credential key hash: 4ff4ae7c2e65fc82423ce3514dc5d62984ea4b2f4756e7d6b15e8169
   reference script: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
@@ -43,6 +43,7 @@
             "amount": {
                 "lovelace": 49999818483
             },
+            "datum": null,
             "network": "Testnet",
             "payment credential key hash": "62573d3d7e30dc551b41fc1e11a9558cba6d0b7b179057aa55963c42",
             "reference script": null,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1778248807,
-        "narHash": "sha256-LI4R+Yl7cy9uO/jWXpo93mUyVMR/UhOoDFVbHV7/abw=",
+        "lastModified": 1779134693,
+        "narHash": "sha256-2vRtxwIvAX4MOAvetH4lqPoKqQ2g6/mlJoBrhlVrGyk=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "61c9835abcfc3a6c9b6279226d4502fa877bb6a7",
+        "rev": "a91041c5d000a3016cc09d3621887599a5f1f4f1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Bump to cardano-api 11.2.0.0. Folds in three migrations that previously
    lived in separate PRs / unreleased branches:

    - Companion to cardano-api #1200: drop deprecated TxBody / TxBodyContent
      uses (was #1375).
    - Companion to cardano-api #1209: migrate createCompatibleTx, toTxOutInEra,
      and toTxOutInShelleyBasedEra to the experimental TxOut plus supplemental
      datum map (was #1376).
    - Companion to cardano-api #1210: legacy Cardano.Api.Certificate module is
      gone; migrate all imports to Cardano.Api.Experimental.Certificate /
      Cardano.Api.Compatible.Certificate as appropriate, and drop vacuous
      hiding clauses that became -Wdodgy-imports errors under -Werror.
  type:
   - maintenance
  projects:
   - cardano-cli
```

# Context

Test run: https://github.com/IntersectMBO/cardano-node-tests/actions/runs/26061932453

Supersedes #1375 and #1376. cardano-api 11.2.0.0 ships these breaking changes:

- #1209 — legacy TxOut removed from Compatible / Experimental APIs
- #1210 — legacy Certificate type + Cardano.Api.Certificate module deleted
- #1211 — six unreachable error constructors removed

Plus two non-breaking notable changes (#1205 evaluateTransaction, #1200 TxBody/TxBodyContent deprecation, #1193 export of evaluateTransactionExecutionUnits).

cardano-api 11.2.0.0 is now published to CHaP (timestamp `2026-05-18T18:23:40Z`). This branch consumes it via the standard CHaP repository — the previous `source-repository-package` pin has been removed and the `cardano-haskell-packages` `index-state` plus the `CHaP` flake input have been bumped past the publish.

# How to trust this PR

- `cabal build cardano-cli -j4` is green against cardano-api 11.2.0.0 from CHaP.
- `cabal test all -j4`: `cardano-cli-test` 69/69 pass; `cardano-cli-golden` 686/686 pass.
- `fourmolu` clean on all touched modules.
- Self-contained commits:
  1. Drop deprecated TxBody from TxBodyFile phantom
  2. Migrate IncompleteTxBody and transaction commands to Exp.UnsignedTx
  3. Remove non-Byron TxOut CtxTx/CtxUTxO usage from cardano-cli
  4. Migrate to experimental TxOut in createCompatibleTx
  5. Bump cardano-api to 11.2.0.0 (via source-repository-package pin)
  6. Migrate to cardano-api 11.2.0.0 Certificate API
  7. cabal.project: bump cardano-api pin to signed 11.2.0.0 commit
  8. cabal.project: drop cardano-api SRP, pull 11.2.0.0 from CHaP

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
- [x] Build green and test suites pass
- [x] `source-repository-package` pin dropped; consuming cardano-api 11.2.0.0 from CHaP