### PR TITLE
Switch to herald for releasing

### DIFF
--- a/.changes/20260519_cardano_cli_friendly_tx_experimental_api.yml
+++ b/.changes/20260519_cardano_cli_friendly_tx_experimental_api.yml
@@ -1,0 +1,7 @@
+project: cardano-cli
+pr: 1374
+kind:
+  - breaking
+  - refactoring
+description: |
+  Migrate the friendly transaction renderer (Cardano.CLI.Compatible.Json.Friendly) off the old-API Tx/TxBody/TxBodyContent onto Exp.SignedTx/Exp.UnsignedTx. The public renderer entry points and every internal helper now use Exp.Era era and Exp.LedgerEra era. cardano-cli debug transaction view and cardano-cli transaction view now only accept Conway and Dijkstra tx/tx-body files. Pre-Conway files fail with a DeprecatedEra error.

--- a/.changes/20260519_cardano_cli_governance_key_output_format.yml
+++ b/.changes/20260519_cardano_cli_governance_key_output_format.yml
@@ -1,0 +1,7 @@
+project: cardano-cli
+pr: 1378
+kind:
+  - feature
+  - compatible
+description: |
+  Add --key-output-bech32/--key-output-text-envelope to governance key-gen commands.

--- a/.changes/20260519_cardano_cli_remove_update_proposal_flag.yml
+++ b/.changes/20260519_cardano_cli_remove_update_proposal_flag.yml
@@ -1,0 +1,6 @@
+project: cardano-cli
+pr: 1372
+kind:
+  - breaking
+description: |
+  Remove the deprecated --update-proposal-file flag from era-based transaction build and transaction build-raw. Update proposals are deprecated since Conway and the flag was already a no-op for Conway+. The flag is kept for compatible <era> transaction signed-transaction where pre-Conway eras still need it.

--- a/.changes/_TEMPLATE.yml
+++ b/.changes/_TEMPLATE.yml
@@ -1,0 +1,27 @@
+# Changelog fragment template - copy this file and fill in the fields.
+# Or use 'herald new' for interactive creation.
+#
+# Files starting with _ are ignored by herald.
+#
+# Available projects and kinds are defined in .herald.yml
+
+# Which project this change belongs to (see 'projects' in .herald.yml)
+project: cardano-cli
+
+# Pull request number associated with this change
+pr: 0
+
+# One or more change kinds (see 'kinds' in .herald.yml)
+kind:
+#   - breaking       # the API has changed in a breaking way
+#   - feature        # introduces a new feature
+#   - compatible     # the API has changed but is non-breaking
+#   - bugfix         # fixes a defect
+#   - optimisation   # measurable performance improvements
+#   - documentation  # change in code docs, haddocks
+#   - refactoring    # code quality improvements
+#   - test           # fixes or modifies tests
+#   - maintenance    # not directly related to the code
+#   - release        # related to a new release preparation
+description: |
+  Describe your change here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,16 @@
-# Changelog
+<!--
+Every PR needs a changelog fragment in `.changes/`.
+Create one from the template at .changes/_TEMPLATE.yml, or use `herald` for interactive creation.
+Run herald with nix: nix run github:input-output-hk/cardano-dev#herald
 
-```yaml
-- description: |
-    <insert-changelog-description-here>
-# uncomment types applicable to the change:
-  type:
-  # - feature        # introduces a new feature
-  # - breaking       # the API has changed in a breaking way
-  # - compatible     # the API has changed but is non-breaking
-  # - optimisation   # measurable performance improvements
-  # - refactoring    # QoL changes
-  # - bugfix         # fixes a defect
-  # - test           # fixes/modifies tests
-  # - maintenance    # not directly related to the code
-  # - release        # related to a new release preparation
-  # - documentation  # change in code docs, haddocks...
-```
+Interactive:
+  herald new
+
+Non-interactive:
+  herald new -p cardano-cli -k bugfix -d "Fix something" --pr 1234
+
+See .herald.yml for full configuration.
+-->
 
 # Context
 
@@ -30,6 +25,7 @@ Highlight important bits of the PR that will make the review faster. If there ar
 - [ ] Commit sequence broadly makes sense and commits have useful messages
 - [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
 - [ ] Self-reviewed the diff
+- [ ] Changelog fragment added in `.changes/`
 
 <!--
 ### Note on CI ###

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,13 +8,13 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Note that, because our Nix configuration provisions *both* shellcheck and actionlint,
       # actionlint is not going to install its own shellcheck.
       # This also makes sure that this pipeline runs using
       # the same shellcheck as the ones in Nix shells of developers.
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/check-cabal-files.yml
+++ b/.github/workflows/check-cabal-files.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/check-cabal-gild.yml
+++ b/.github/workflows/check-cabal-gild.yml
@@ -8,9 +8,9 @@ jobs:
   check-cabal-gild:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/check-git-dependencies.yml
+++ b/.github/workflows/check-git-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Check git dependencies
       run: |

--- a/.github/workflows/check-hlint.yml
+++ b/.github/workflows/check-hlint.yml
@@ -14,6 +14,6 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: haskell-actions/hlint-scan@v1

--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -1,88 +1,33 @@
-name: Check if PR changelog was filled correctly
+name: Check changelog fragments
+
+permissions:
+  contents: read
+
 on:
+  # since this is required check, we need to run it in merge_group, otherwise merge queue will stall waiting
+  # for a status that never arrives
   merge_group:
   pull_request:
-    types: [opened, edited, synchronize, ready_for_review]
+    types: [opened, synchronize, ready_for_review]
 
 jobs:
   check-changelog:
+    # Skip for merge_group: batched diffs would cause false positives and
+    # PR number context is unavailable.  The trigger is kept so the check
+    # reports "skipped" (passes) when this is a required status check.
+    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        if: ${{ github.event_name != 'merge_group' }}
+      - uses: actions/checkout@v6
         with:
-          node-version: 22
+          fetch-depth: 0
 
-      - run: npm install js-yaml@4.1.0
-        if: ${{ github.event_name != 'merge_group' }}
-
-      - name: Fail if PR changelog is not correct
-        if: ${{ github.event_name != 'merge_group' }}
-        uses: actions/github-script@v7
-        id: check-changelog
+      - uses: cachix/install-nix-action@v31
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const yaml = require('js-yaml');
-            const fs   = require('fs');
+          extra_nix_config: |
+            accept-flake-config = true
 
-            const prDescription = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
-            const changelogRegex = /# Changelog[\s\S]*?```yaml([\s\S]*?)```/;
-            const changelogMatch = prDescription.data.body.match(changelogRegex);
-            const yamlContent = changelogMatch ? changelogMatch[1].trim() : '';
-            yamlContent || console.error('Failed to find changelog YAML section in the "Changelog" paragraph');
-
-            try {
-              changelog = yaml.load(yamlContent)[0];
-            } catch (e) {
-              console.error('Failed to parse YAML changelog as array:', yamlContent);
-              process.exit(1);
-            }
-
-            try {
-              config = yaml.load(fs.readFileSync('.cardano-dev.yaml', 'utf8'));
-            } catch (e) {
-              console.error('Failed to load .cardano-dev.yaml config:', e);
-              process.exit(1);
-            }
-
-            let isCompatibilityValid = false;
-            if (!changelog.compatibility) {
-              isCompatibilityValid = true;
-            }
-            if (!isCompatibilityValid) {
-              console.error('Changelog field "compatibility" is deprecated and no longer used. Please remove it.');
-            }
-
-            let isTypeValid = false;
-            const validTypeValues = Object.keys(config.changelog.options.type);
-            if (Array.isArray(changelog.type) && !!changelog.type) {
-              isTypeValid = changelog.type.every(value => validTypeValues.includes(value));
-            } else {
-              isTypeValid = validTypeValues.includes(changelog.type);
-            }
-            if (!isTypeValid) {
-              console.error(`PR changelog has invalid type: ${changelog.type}\nExpected one, or more of: ${validTypeValues}`)
-            }
-
-            let isDescriptionValid = true;
-            if (changelog.description.trim() === '<insert-changelog-description-here>') {
-              console.error('PR changelog description has not been updated!')
-              isDescriptionValid = false;
-            } else if (!changelog.description.trim()) {
-              console.error('PR changelog description field is missing!')
-              isDescriptionValid = false;
-            }
-
-            if (!isCompatibilityValid || !isTypeValid || !isDescriptionValid) {
-              console.error('Failed PR changelog checks!');
-              process.exit(1);
-            }
-
+      # TODO: enable --pr check after backfilling existing PRs with fragments
+      - uses: input-output-hk/cardano-dev/actions/herald-validate@herald-validate-0.0.1.0
+        with:
+          pr: false

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -15,9 +15,9 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Cache and install Cabal dependencies
-      uses: intersectmbo/cardano-api/.github/actions/cabal-cache@a7bd74dfa6ccb1eb04f69791f978a3b9e0cc63ca
+      uses: input-output-hk/cardano-dev/actions/cabal-cache@cabal-cache-0.0.1.0
       with:
         cabal-store: ${{ steps.setup-haskell.outputs.cabal-store }}
         cache-version: ${{ env.CABAL_CACHE_VERSION }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -87,7 +87,7 @@ jobs:
       with:
         use-sodium-vrf: true # default is true
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Cache and install Cabal dependencies
       uses: input-output-hk/cardano-dev/actions/cabal-cache@cabal-cache-0.0.1.0

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check if changes were trivial
         id: check_trivial_changes
@@ -76,7 +76,7 @@ jobs:
             echo "CHECK_HLS_WORKS=1" >> "$GITHUB_OUTPUT"
             echo "Some changes are non-trivial. We need to do the checks!"
           fi
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         if: steps.check_trivial_changes.outputs.CHECK_HLS_WORKS > 0
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/markdown-links-ci-check.yml
+++ b/.github/workflows/markdown-links-ci-check.yml
@@ -8,7 +8,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: |
        cat <<EOF > mlc_config.json
        {

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -58,7 +58,7 @@ jobs:
       DRY_RUN:    ${{ steps.store_vars.outputs.DRY_RUN }}
       FLAKE_REF:  ${{ steps.store_vars.outputs.FLAKE_REF }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Because the target tag may not be HEAD
           fetch-tags: true # So that tags are known to git commands
@@ -139,7 +139,7 @@ jobs:
     name: "Download Asset"
     runs-on: ubuntu-latest
     steps:
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.wait_for_hydra.outputs.DRY_RUN == 'false' }}
     steps:
-      - uses: actions/checkout@v4 # We need the repo to execute extract-changelog.sh  below
+      - uses: actions/checkout@v6 # We need the repo to execute extract-changelog.sh  below
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package to release (must match a project in .herald.yml)'
+        required: true
+        type: choice
+        options:
+          - cardano-cli
+      version:
+        description: 'Explicit version (A.B.C.D). Leave empty for auto-bump.'
+        required: false
+        type: string
+      branch:
+        description: 'Branch to release from and target for the PR. Leave empty to use the branch selected above.'
+        required: false
+        type: string
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch || github.ref_name }}
+          fetch-depth: 0
+
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+
+      - uses: input-output-hk/cardano-dev/actions/herald-release@herald-release-0.0.1.0
+        with:
+          package: ${{ inputs.package }}
+          version: ${{ inputs.version }}
+          base-branch: ${{ inputs.branch || github.ref_name }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,9 +14,9 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: cachix/install-nix-action@v30
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-unstable
           extra_nix_config: |

--- a/.herald.yml
+++ b/.herald.yml
@@ -1,0 +1,67 @@
+# Herald configuration
+# Changelog and release automation for PVP-versioned Haskell projects
+
+# Git repository URL (used for PR links in changelogs)
+git-repo: intersectmbo/cardano-cli
+
+# Directory for changelog fragments, relative to repo root
+# Fragments are YAML files created by 'herald new' and consumed by 'herald batch'
+changes-dir: .changes
+
+# Change kinds and their properties
+#
+# Each kind defines:
+#   notable: if true (default), changes of this kind appear in the changelog
+#           if false, they still bump the version but are omitted from the changelog text
+#   bump:    PVP version component to bump when this kind is present
+#           0.1.0.0 = bump 2nd component (breaking changes)
+#           0.0.1.0 = bump 3rd component (features, compatible changes)
+#           0.0.0.1 = bump 4th component (patches, internal changes)
+#
+# The highest bump across all fragment kinds determines the final version bump.
+kinds:
+  breaking:
+    bump: 0.1.0.0
+    description: the API has changed in a breaking way
+  bugfix:
+    bump: 0.0.0.1
+    description: fixes a defect
+  compatible:
+    bump: 0.0.1.0
+    description: the API has changed but is non-breaking
+  documentation:
+    notable: false
+    bump: 0.0.0.1
+    description: change in code docs, haddocks
+  feature:
+    bump: 0.0.1.0
+    description: introduces a new feature
+  maintenance:
+    notable: false
+    bump: 0.0.0.1
+    description: not directly related to the code
+  optimisation:
+    bump: 0.0.0.1
+    description: measurable performance improvements
+  refactoring:
+    notable: false
+    bump: 0.0.0.1
+    description: code quality improvements
+  release:
+    notable: false
+    bump: 0.0.0.1
+    description: related to a new release preparation
+  test:
+    notable: false
+    bump: 0.0.0.1
+    description: fixes or modifies tests
+
+# Projects in this repository
+#
+# Each project needs:
+#   changelog:  path to the project's CHANGELOG.md (relative to repo root)
+#   cabal-file: (optional) path to the project's .cabal file (version is read/updated here)
+projects:
+  cardano-cli:
+    changelog: cardano-cli/CHANGELOG.md
+    cabal-file: cardano-cli/cardano-cli.cabal


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Switch to herald for releasing
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
Switch to herald for releasing. This PR is a copy of changes from https://github.com/IntersectMBO/cardano-api/pull/1164

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
