### PR TITLE
Add pre-commit hooks guidance to CONTRIBUTING.md

### DIFF
--- a/.changes/20260602_013028_cardano-cli_pablo.lamela_document_commit_hook_issues.yml
+++ b/.changes/20260602_013028_cardano-cli_pablo.lamela_document_commit_hook_issues.yml
@@ -1,4 +1,4 @@
-description: Added explanation about precommit gotchas to CONTRIBUTING.md
+description: Added explanation about pre-commit gotchas to CONTRIBUTING.md
 kind:
 - documentation
 pr: 1388

--- a/.changes/20260602_013028_cardano-cli_pablo.lamela_document_commit_hook_issues.yml
+++ b/.changes/20260602_013028_cardano-cli_pablo.lamela_document_commit_hook_issues.yml
@@ -1,0 +1,5 @@
+description: Added explanation about precommit gotchas to CONTRIBUTING.md
+kind:
+- documentation
+pr: 1388
+project: cardano-cli

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,12 +43,10 @@ In that case, release a patched version to the [CHaP repository][CHaP], which al
 
 ## Pre-commit hooks
 
-This repository, as well as `cardano-api`, uses pre-commit hooks (e.g. `cabal-gild`) to enforce
-formatting and consistency. These tools are provided by the Nix development shell, so you can
-get the right versions of each tool by entering it (via `nix develop`) before committing.
+This repository, as well as `cardano-api`, uses pre-commit hooks (e.g. `cabal-gild`) to enforce formatting and consistency.
+These tools are provided by the Nix development shell, so you can get the right versions of each tool by entering it (via `nix develop`) before committing.
 
-If you need to make a work-in-progress commit and the hooks are failing (for example, because you are
-working outside of the Nix shell), you can bypass them with:
+If you need to make a work-in-progress commit and the hooks are failing (for example, because you are working outside of the Nix shell), you can bypass them with:
 
 ```bash
 git commit --no-verify
@@ -56,9 +54,8 @@ git commit --no-verify
 
 Make sure to fix any hook issues before opening a pull request.
 
-It can also happen that you have a broken build (e.g. while work is in progress), which can prevent you from entering the Nix development shell. The easiest workaround is probably checking
-out a version that does build (e.g. `master`) by either stashing the changes or checking it out in a different folder,
-and then going back to the version with the broken build once you are already inside the Nix development shell.
+It can also happen that you have a broken build (e.g. while work is in progress), which can prevent you from entering the Nix development shell.
+The easiest workaround is probably checking out a version that does build (e.g. `master`) by either stashing the changes or checking it out in a different folder, and then going back to the version with the broken build once you are already inside the Nix development shell.
 
 Alternatively, you can download the appropriate versions of each tool used by the pre-commit hooks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,7 @@ In that case, release a patched version to the [CHaP repository][CHaP], which al
 
 This repository, as well as `cardano-api`, uses pre-commit hooks (e.g. `cabal-gild`) to enforce
 formatting and consistency. These tools are provided by the Nix development shell, so you can
-get the right versions of each by entering it (via `nix develop`) before committing
-to ensure the hooks work correctly.
+get the right versions of each tool by entering it (via `nix develop`) before committing.
 
 If you need to make a work-in-progress commit and the hooks are failing (for example, because you are
 working outside of the Nix shell), you can bypass them with:
@@ -57,10 +56,9 @@ git commit --no-verify
 
 Make sure to fix any hook issues before opening a pull request.
 
-It sometimes also happens that you may have a broken build (maybe because it is a work in progress) and
-that may prevent you from entering the Nix development shell. The easiest workaround is probably checking
-out a version that does build, e.g. `master`, (by either stashing the changes or checking it out in a different folder)
-and then going back to the version with the broken build once already inside the Nix development shell.
+It can also happen that you have a broken build (e.g. while work is in progress), which can prevent you from entering the Nix development shell. The easiest workaround is probably checking
+out a version that does build (e.g. `master`) by either stashing the changes or checking it out in a different folder,
+and then going back to the version with the broken build once you are already inside the Nix development shell.
 
 Alternatively, you can download the appropriate versions of each tool used by the pre-commit hooks.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,29 @@ provide a [`--sha256` comment in `cabal.project`](https://input-output-hk.github
 For packages that we do not control, we can end up in a situation where we have a fork that looks like it will be long-lived or permanent (e.g. the maintainer is unresponsive, or the change has been merged but not released).
 In that case, release a patched version to the [CHaP repository][CHaP], which allows us to remove the `source-repository-package` stanza.
 
+## Pre-commit hooks
+
+This repository, as well as `cardano-api`, uses pre-commit hooks (e.g. `cabal-gild`) to enforce
+formatting and consistency. These tools are provided by the Nix development shell, so you can
+get the right versions of each by entering it (via `nix develop`) before committing
+to ensure the hooks work correctly.
+
+If you need to make a work-in-progress commit and the hooks are failing (for example, because you are
+working outside of the Nix shell), you can bypass them with:
+
+```bash
+git commit --no-verify
+```
+
+Make sure to fix any hook issues before opening a pull request.
+
+It sometimes also happens that you may have a broken build (maybe because it is a work in progress) and
+that may prevent you from entering the Nix development shell. The easiest workaround is probably checking
+out a version that does build, e.g. `master`, (by either stashing the changes or checking it out in a different folder)
+and then going back to the version with the broken build once already inside the Nix development shell.
+
+Alternatively, you can download the appropriate versions of each tool used by the pre-commit hooks.
+
 ## Troubleshooting
 
 ### `<stdout>: commitBuffer: invalid argument (invalid character)` error when launching tests


### PR DESCRIPTION
# Context

Contributors working outside of the Nix development shell encounter confusing failures from pre-commit hooks (e.g. `cabal-gild` not found). This documents the requirement and common workarounds.

# How to trust this PR

Documentation-only change to `CONTRIBUTING.md`. No code changes.

Review the diff — it adds a new "Pre-commit hooks" section covering:
- The Nix shell requirement for hook tools
- Using `--no-verify` for WIP commits
- Workaround for broken builds that prevent entering the Nix shell

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`