### PR TITLE
Migrate from optparse-applicative-fork to optparse-applicative 0.19

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -280,7 +280,7 @@ library
     mtl,
     network,
     network-uri,
-    optparse-applicative-fork,
+    optparse-applicative ^>=0.19,
     ordered-containers,
     prettyprinter,
     prettyprinter-ansi-terminal,
@@ -310,7 +310,7 @@ executable cardano-cli
     cardano-api,
     cardano-cli,
     cardano-crypto-class,
-    optparse-applicative-fork,
+    optparse-applicative ^>=0.19,
     rio,
     terminal-size,
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.EraBased.Transaction.Option
   )
 where
 
-import Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..), yellow)
 import Cardano.Api.Experimental qualified as Exp
 
 import Cardano.CLI.Environment (EnvCli (..))
@@ -32,6 +32,12 @@ import Options.Applicative hiding (help, str)
 import Options.Applicative qualified as Opt
 import Options.Applicative.Help qualified as H
 import Prettyprinter (line)
+
+yellow :: H.Doc -> H.Doc
+yellow = H.annotate (H.color H.Yellow)
+
+underline :: H.Doc -> H.Doc
+underline = H.annotate H.underlined
 
 pTransactionCmds
   :: Exp.IsEra era
@@ -55,10 +61,10 @@ pTransactionCmds envCli =
                     [ pretty @String "Build a transaction (low-level, inconvenient)"
                     , line
                     , line
-                    , H.yellow $
+                    , yellow $
                         mconcat
                           [ "Please note "
-                          , H.underline "the order"
+                          , underline "the order"
                           , " of some cmd options is crucial. If used incorrectly may produce "
                           , "undesired tx body. See nested [] notation above for details."
                           ]
@@ -179,10 +185,10 @@ pTransactionBuildCmd envCli = do
                 [ pretty @String "Build a balanced transaction (automatically calculates fees)"
                 , line
                 , line
-                , H.yellow $
+                , yellow $
                     mconcat
                       [ "Please note "
-                      , H.underline "the order"
+                      , underline "the order"
                       , " of some cmd options is crucial. If used incorrectly may produce "
                       , "undesired tx body. See nested [] notation above for details."
                       ]
@@ -243,10 +249,10 @@ pTransactionBuildEstimateCmd _envCli = do
                     "Build a balanced transaction without access to a live node (automatically estimates fees)"
                 , line
                 , line
-                , H.yellow $
+                , yellow $
                     mconcat
                       [ "Please note "
-                      , H.underline "the order"
+                      , underline "the order"
                       , " of some cmd options is crucial. If used incorrectly may produce "
                       , "undesired tx body. See nested [] notation above for details."
                       ]

--- a/cardano-cli/src/Cardano/CLI/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Option.hs
@@ -25,13 +25,11 @@ import Cardano.CLI.EraIndependent.Node.Option
 import Cardano.CLI.EraIndependent.Ping.Option (parsePingCmd)
 import Cardano.CLI.Legacy.Option (parseLegacyCmds)
 import Cardano.CLI.Parser
-import Cardano.CLI.Render (customRenderHelp)
 import Cardano.CLI.Run (ClientCommand (..))
 
 import Data.Foldable
 import Options.Applicative
 import Options.Applicative qualified as Opt
-import Prettyprinter qualified as PP
 
 opts :: EnvCli -> ParserInfo ClientCommand
 opts envCli =
@@ -51,8 +49,7 @@ pref =
   Opt.prefs $
     mconcat
       [ showHelpOnEmpty
-      , helpEmbedBriefDesc PP.align
-      , helpRenderHelp customRenderHelp
+      , briefHangPoint 35
       ]
 
 addressCmdsTopLevel :: EnvCli -> Parser ClientCommand

--- a/cardano-cli/src/Cardano/CLI/Render.hs
+++ b/cardano-cli/src/Cardano/CLI/Render.hs
@@ -4,64 +4,12 @@ module Cardano.CLI.Render
   )
 where
 
-import Cardano.Api (textShow)
-
 import Data.Text (Text)
-import Data.Text qualified as T
-import Options.Applicative
-import Options.Applicative.Help.Ann
-import Options.Applicative.Help.Types (helpText, renderHelp)
+import Options.Applicative.Help.Types (ParserHelp, renderHelp)
 import Prettyprinter
-import Prettyprinter.Render.Util.SimpleDocTree
-import System.Environment qualified as IO
-import System.IO.Unsafe qualified as IO
 
-cliHelpTraceEnabled :: Bool
-cliHelpTraceEnabled = IO.unsafePerformIO $ do
-  mValue <- IO.lookupEnv "CLI_HELP_TRACE"
-  return $ mValue == Just "1"
-{-# NOINLINE cliHelpTraceEnabled #-}
-
--- | Convert a help text to 'String'.  When the CLI_HELP_TRACE environment variable is set
--- to '1', the output will be in HTML so that it can be viewed in a browser where developer
--- tools can be used to inspect tracing that aids in describing the structure of the output
--- document.
 customRenderHelp :: Int -> ParserHelp -> String
-customRenderHelp =
-  if cliHelpTraceEnabled
-    then customRenderHelpAsHtml
-    else customRenderHelpAsAnsi
-
-customRenderHelpAsHtml :: Int -> ParserHelp -> String
-customRenderHelpAsHtml cols =
-  T.unpack
-    . wrapper
-    . renderSimplyDecorated id renderElement
-    . treeForm
-    . layoutSmart (LayoutOptions (AvailablePerLine cols 1.0))
-    . helpText
- where
-  renderElement :: Ann -> Text -> Text
-  renderElement ann x =
-    if cliHelpTraceEnabled
-      then case ann of
-        AnnTrace _ name -> "<span name=" <> textShow name <> ">" <> x <> "</span>"
-        AnnStyle _ -> x
-      else x
-  wrapper =
-    if cliHelpTraceEnabled
-      then
-        id
-          . ("<html>\n" <>)
-          . ("<body>\n" <>)
-          . ("<pre>\n" <>)
-          . (<> "\n</html>")
-          . (<> "\n</body>")
-          . (<> "\n</pre>")
-      else id
-
-customRenderHelpAsAnsi :: Int -> ParserHelp -> String
-customRenderHelpAsAnsi = renderHelp
+customRenderHelp = renderHelp
 
 renderAnyCmdError :: Text -> (a -> Doc ann) -> a -> Doc ann
 renderAnyCmdError cmdText renderer shelCliCmdErr =


### PR DESCRIPTION
## Summary

Replace `optparse-applicative-fork 0.18.1.0` with upstream `optparse-applicative 0.19.0.0`.

Upstream has incorporated the two features that motivated the fork:
- [PR #428](https://github.com/pcapriotti/optparse-applicative/pull/428) — prettyprinter switch (upstream 0.18.0.0)
- [PR #425](https://github.com/pcapriotti/optparse-applicative/pull/425) — smart brief description formatting (upstream 0.19.0.0 as `briefHangPoint`)

### Capability regressions

Two fork-specific hooks have no upstream equivalent:

- **`prefRenderHelp`** (`helpRenderHelp` in prefs) — the fork allowed injecting a custom renderer into all `--help` output. Upstream has no such hook. `customRenderHelp` now only covers the explicit `cardano-cli help` command path; `--help` on subcommands goes straight through optparse's built-in `renderHelp`.

- **`helpEmbedBriefDesc PP.align`** — the fork took a `Doc -> Doc` function for full control over usage line overflow. Upstream only has `briefHangPoint :: Int -> PrefsMod`, replaced here with `briefHangPoint 35`. The formatting output will differ.

### Other changes

- `Render.hs`: remove fork-specific `Ann`/`AnnTrace` HTML tracing; simplify to `customRenderHelp = renderHelp`. The `CLI_HELP_TRACE` feature was never wired up (no `annTrace` call sites) so nothing functional is lost.
- `Transaction/Option.hs`: `H.yellow`/`H.underline` replaced with local helpers via `H.annotate` — upstream re-exports `Prettyprinter.Render.Terminal` so the capability is there, just not pre-wrapped.

### Golden tests

The 492 help text golden files will need updating due to formatting differences from `briefHangPoint 35` vs `helpEmbedBriefDesc PP.align`.

# Changelog

```yaml
- description: |
    Migrate from optparse-applicative-fork to upstream optparse-applicative 0.19.0.0
  type:
    - maintenance
```

# Context

Upstream has caught up with the two IOG PRs that motivated the fork. The fork's additional hooks (`prefRenderHelp`, `helpEmbedBriefDesc`) are lost but may be worth raising with upstream if the formatting differences are unacceptable.

# How to trust this PR

- Compiles cleanly against `optparse-applicative 0.19.0.0`
- Only removes dead code and rewires existing functionality to upstream equivalents

# Checklist

- [x] Compiles
- [ ] Golden tests updated (follow-up)