### PR TITLE
Fix help text of URL options to list the actually supported schemes

### DIFF
--- a/.changes/20260718_044307_cardano-cli_pablo.lamela_fix_anchor_url_help_messages.yml
+++ b/.changes/20260718_044307_cardano-cli_pablo.lamela_fix_anchor_url_help_messages.yml
@@ -1,0 +1,6 @@
+description: Fix help messages in anchor hashing functions to display the right protocols
+  supported
+kind:
+- bugfix
+pr: 1396
+project: cardano-cli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
@@ -186,5 +186,8 @@ pDRepMetadataSource :: Parser DRepMetadataSource
 pDRepMetadataSource =
   asum
     [ DrepMetadataFileIn <$> pFileInDirection "drep-metadata-file" "JSON Metadata file to hash."
-    , DrepMetadataURL <$> pUrl "drep-metadata-url" "URL pointing to the JSON Metadata file to hash."
+    , DrepMetadataURL
+        <$> pUrl
+          "drep-metadata-url"
+          "URL pointing to the JSON Metadata file to hash. Supported schemes are: file, http, https, ipfs."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
@@ -77,7 +77,9 @@ pPoolMetadataSource =
   F.asum
     [ Cmd.StakePoolMetadataFileIn <$> pPoolMetadataFile
     , Cmd.StakePoolMetadataURL
-        <$> pUrl "pool-metadata-url" "URL pointing to the JSON Metadata file to hash."
+        <$> pUrl
+          "pool-metadata-url"
+          "URL pointing to the JSON Metadata file to hash. Supported schemes are: file, http, https, ipfs."
     ]
 
 pPoolMetadataHashGoal :: Parser (Cmd.HashGoal (Hash StakePoolMetadata))

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Hash/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Hash/Option.hs
@@ -64,7 +64,7 @@ pAnchorDataHashSource =
     , Cmd.AnchorDataHashSourceTextFile
         <$> pFileInDirection "file-text" "Text file to hash"
     , Cmd.AnchorDataHashSourceURL
-        <$> pUrl "url" "A URL to the file to hash (HTTP(S) and IPFS only)"
+        <$> pUrl "url" "A URL to the file to hash. Supported schemes are: file, http, https, ipfs."
     ]
 
 pHashScriptCmd :: Parser Cmd.HashCmds

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_metadata-hash.cli
@@ -13,6 +13,7 @@ Available options:
   --drep-metadata-file FILEPATH
                            JSON Metadata file to hash.
   --drep-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+                           Supported schemes are: file, http, https, ipfs.
   --expected-hash HASH     Expected hash for the DRep metadata, for verification
                            purposes. If provided, the hash of the DRep metadata
                            will be compared to this value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_metadata-hash.cli
@@ -13,6 +13,7 @@ Available options:
   --drep-metadata-file FILEPATH
                            JSON Metadata file to hash.
   --drep-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+                           Supported schemes are: file, http, https, ipfs.
   --expected-hash HASH     Expected hash for the DRep metadata, for verification
                            purposes. If provided, the hash of the DRep metadata
                            will be compared to this value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
@@ -13,6 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+                           Supported schemes are: file, http, https, ipfs.
   --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/hash_anchor-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/hash_anchor-data.cli
@@ -14,7 +14,8 @@ Available options:
   --text TEXT              Text to hash as UTF-8
   --file-binary FILEPATH   Binary file to hash
   --file-text FILEPATH     Text file to hash
-  --url TEXT               A URL to the file to hash (HTTP(S) and IPFS only)
+  --url TEXT               A URL to the file to hash. Supported schemes are:
+                           file, http, https, ipfs.
   --expected-hash HASH     Expected hash for the anchor data, for verification
                            purposes. If provided, the hash of the anchor data
                            will be compared to this value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_metadata-hash.cli
@@ -13,6 +13,7 @@ Available options:
   --drep-metadata-file FILEPATH
                            JSON Metadata file to hash.
   --drep-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+                           Supported schemes are: file, http, https, ipfs.
   --expected-hash HASH     Expected hash for the DRep metadata, for verification
                            purposes. If provided, the hash of the DRep metadata
                            will be compared to this value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
@@ -13,6 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+                           Supported schemes are: file, http, https, ipfs.
   --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.


### PR DESCRIPTION

# Context

The help for `hash anchor-data --url` claimed that only HTTP(S) and IPFS URLs are supported, but the URL is fetched with `allSchemes`, which also accepts file:// URLs. Conversely, `--pool-metadata-url` (`stake-pool metadata-hash`) and `--drep-metadata-url` (`governance drep metadata-hash`), which are also fetched with `allSchemes`, did not document which schemes they accept at all.

This PR updates the help for these command so that it correctly describes the supported schemas.

# How to trust this PR

Check the messages are written correctly and that the implementation of these commands indeed use `allSchemes`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
