### PR TITLE
Replace closed-range eon eliminators with forEraInEon in cardano-cli

### DIFF
--- a/.changes/remove-closed-range-eon-eliminators.yml
+++ b/.changes/remove-closed-range-eon-eliminators.yml
@@ -1,0 +1,6 @@
+description: |
+  Replaced the `caseShelleyToAllegraOrMaryEraOnwards`, `caseShelleyToAlonzoOrBabbageEraOnwards` and `caseShelleyToMaryOrAlonzoEraOnwards` eon eliminators with `forEraInEon` in transaction, query and governance option parsing. No behavioural change. This removes the last cardano-cli uses of the `ShelleyToAllegraEra`, `ShelleyToAlonzoEra` and `ShelleyToMaryEra` eons.
+kind:
+- refactoring
+pr: 1397
+project: cardano-cli

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
@@ -87,9 +87,10 @@ pTxOutEraAware sbe =
     <*> pRefScriptFp sbe
 
 pTxOutDatum :: ShelleyBasedEra era -> Parser TxOutDatumAnyEra
-pTxOutDatum =
-  caseShelleyToMaryOrAlonzoEraOnwards
-    (const $ pure TxOutDatumByNone)
+pTxOutDatum sbe =
+  forEraInEon
+    (convert sbe)
+    (pure TxOutDatumByNone)
     ( \case
         AlonzoEraOnwardsAlonzo ->
           pAlonzoDatumFunctionality <|> pure TxOutDatumByNone

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/TxOut.hs
@@ -83,13 +83,13 @@ toTxOutValueInShelleyBasedEra
   -> Value
   -> CIO e (TxOutValue era)
 toTxOutValueInShelleyBasedEra sbe val =
-  caseShelleyToAllegraOrMaryEraOnwards
-    ( \_ -> case valueToLovelace val of
-        Just l -> return (TxOutValueShelleyBased sbe l)
+  forEraInEon
+    (convert sbe)
+    ( case valueToLovelace val of
+        Just l -> return (lovelaceToTxOutValue sbe l)
         Nothing -> txFeatureMismatch sbe TxFeatureMultiAssetOutputs
     )
-    (\w -> return (TxOutValueShelleyBased sbe (toLedgerValue w val)))
-    sbe
+    (\w -> maryEraOnwardsConstraints w $ return (TxOutValueShelleyBased sbe (toLedgerValue w val)))
 
 toTxAlonzoDatum
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
@@ -195,9 +195,10 @@ pUpdateProtocolParametersCmd =
 -- | Cost models only makes sense in eras from Alonzo onwards. For earlier
 -- eras, this parser doesn't show up in the command line and returns 'Nothing'.
 pCostModelsFile :: ShelleyBasedEra era -> Parser (Maybe (CostModelsFile era))
-pCostModelsFile =
-  caseShelleyToMaryOrAlonzoEraOnwards
-    (const $ pure Nothing)
+pCostModelsFile sbe =
+  forEraInEon
+    (convert sbe)
+    (pure Nothing)
     ( \alonzoOnwards ->
         fmap (CostModelsFile alonzoOnwards . File)
           <$> optional pCostModels

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Run.hs
@@ -1251,10 +1251,10 @@ utxoToText sbe (TxIn (TxId txhash) (TxIx index), Exp.TxOut ledgerTxOut) =
   -- datum where it exists and an empty placeholder otherwise.
   printableDatum :: Text
   printableDatum =
-    caseShelleyToAlonzoOrBabbageEraOnwards
-      (const "")
+    forEraInEon
+      (convert sbe)
+      ""
       (\beo -> babbageEraOnwardsConstraints beo $ Text.pack $ show (ledgerTxOut ^. L.datumTxOutL))
-      sbe
 
 runQueryStakePoolsCmd
   :: ()


### PR DESCRIPTION
# Context

Part of removing eon witnesses from `cardano-cli` in favour of `ShelleyBasedEra era` / the experimental `Era era`.

This PR rewrites the four `cardano-cli` call sites of the closed-range eon eliminators to use `forEraInEon` on the `CardanoEra`, keyed on the surviving `*EraOnwards` eon:

| site | was | now |
|---|---|---|
| `Compatible/Transaction/TxOut.hs` `toTxOutValueInShelleyBasedEra` | `caseShelleyToAllegraOrMaryEraOnwards` | `forEraInEon` (MaryEraOnwards) |
| `EraBased/Query/Run.hs` `printableDatum` | `caseShelleyToAlonzoOrBabbageEraOnwards` | `forEraInEon` (BabbageEraOnwards) |
| `Compatible/Transaction/Option.hs` `pTxOutDatum` | `caseShelleyToMaryOrAlonzoEraOnwards` | `forEraInEon` (AlonzoEraOnwards) |
| `EraBased/Governance/Actions/Option.hs` `pCostModelsFile` | `caseShelleyToMaryOrAlonzoEraOnwards` | `forEraInEon` (AlonzoEraOnwards) |

This removes the last `cardano-cli` uses of `ShelleyToAllegraEra`, `ShelleyToAlonzoEra` and `ShelleyToMaryEra`, which unblocks deleting those (consumerless) eons from `cardano-api`.

# How to trust this PR

Behaviour is unchanged at every site — `forEraInEon`'s negative branch fires for exactly the same sub-cutoff eras the `caseShelleyToXOr…` lower branch did.

Verified with `cabal build cardano-cli -j4` (lib, exe, and golden tests compile and link).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] Self-reviewed the diff
- [x] Changelog fragment added in `.changes/`
